### PR TITLE
simulator: neopixels memory layout fix

### DIFF
--- a/simulator/src/runtime.ts
+++ b/simulator/src/runtime.ts
@@ -66,13 +66,13 @@ export class Runtime {
     }
 
     getNeopixels (): [number, number, number, number, number] {
-        const mem32 = new Uint32Array(this.data.buffer, constants.ADDR_NEOPIXELS);
+        const mem8 = new Uint8Array(this.data.buffer, constants.ADDR_NEOPIXELS);
         return [
-            mem32[0] & 0b1111_1111_1111_1111_1111_1111,
-            mem32[1] & 0b1111_1111_1111_1111_1111_1111,
-            mem32[2] & 0b1111_1111_1111_1111_1111_1111,
-            mem32[3] & 0b1111_1111_1111_1111_1111_1111,
-            mem32[4] & 0b1111_1111_1111_1111_1111_1111
+            mem8[0] | (mem8[1] << 8) | (mem8[2] << 16),
+            mem8[3] | (mem8[4] << 8) | (mem8[5] << 16),
+            mem8[6] | (mem8[7] << 8) | (mem8[8] << 16),
+            mem8[9] | (mem8[10] << 8) | (mem8[11] << 16),
+            mem8[12] | (mem8[13] << 8) | (mem8[14] << 16),
         ];
     }
 

--- a/simulator/src/ui/utils.ts
+++ b/simulator/src/ui/utils.ts
@@ -52,5 +52,5 @@ export function unpack565(bgr565: number): [number, number, number] {
 }
 
 export function unpack888(bgr888: number): [number, number, number] {
-    return [bgr888 >> 16, bgr888 >> 8 & 0b11111111, bgr888 & 0b11111111];
+    return [(bgr888 >> 8) & 0b11111111, bgr888 & 0b11111111, bgr888 >> 16];
 }


### PR DESCRIPTION
the actual `neopixels` layout is `g r b g r b g r b g r b g r b`, so I replaced `Uint32Array` with `Uint8Array` and adjusted u32 -> u8 u8 u8 parsing order