### PR TITLE
Tracy support

### DIFF
--- a/src/os/drivers/audio.zig
+++ b/src/os/drivers/audio.zig
@@ -38,6 +38,8 @@ const audio_levels = 250;
 /// too fast for humans to hear (or for the speaker to even create)
 const audio_pwm_cycle_hz = 500_000;
 
+const max_sample_rate = 44100;
+
 // Make sure the above values are consistent with the hardware.
 // They are all important so we specify them all instead of calculating any of them
 comptime { std.debug.assert(buzzer_sys_clk_hz == audio_levels * audio_pwm_cycle_hz * buzzer_pwm_clk_div); }
@@ -227,8 +229,7 @@ pub fn poll() void {
                 }
             }
             const end = timer.micros();
-            fps_overlay.submit_audio_mix_time(start, end, mix_request_time[mix_idx]);
-            mix_request_time[mix_idx] = 0;
+            fps_overlay.submit_audio_mix_time(start, end, 1000000 * dma_buf_size / max_sample_rate);
             mix_idx = 1 - mix_idx;
         }
     }
@@ -293,7 +294,7 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32, flags: u32) void {
         },
         else => {
             const sample_freq = @as(comptime_float, audio_levels) * freq_hz;
-            const max_freq = 44100.0 / 2.0;
+            const max_freq = max_sample_rate;
             if (sample_freq <= max_freq) {
                 period_per_sample = 1.0 / @as(comptime_float, audio_levels);
                 setup_ping_pong_DMA(duration_sec, sample_freq) catch {

--- a/src/os/drivers/audio.zig
+++ b/src/os/drivers/audio.zig
@@ -21,6 +21,7 @@ const std = @import("std");
 
 const timer = @import("timer.zig");
 const fps_overlay = @import("../system/fps_overlay.zig");
+const terry = @import("../system/terry.zig");
 
 // Aliases for the DMA control registers to avoid triggering DMA start.
 const DMA_CH1_AL1_CTRL: *volatile @TypeOf(DMA.CH1_CTRL_TRIG) = @ptrCast(&DMA.CH1_AL1_CTRL);
@@ -217,6 +218,9 @@ pub fn poll() void {
         const buffer_bit: u32 = @as(u32, 1) << @intCast(mix_idx + 1);
         if (mix_ready & buffer_bit != 0) {
             mix_ready &= ~buffer_bit;
+
+            const z = terry.core0.zone("Audio Mix", @src()); defer z.end();
+
             const start = timer.micros();
             const more_buffers = mix_buffer(&audio_dma_buf[mix_idx]);
             std.mem.doNotOptimizeAway(&audio_dma_buf[mix_idx]);

--- a/src/os/drivers/lcd.zig
+++ b/src/os/drivers/lcd.zig
@@ -9,6 +9,7 @@ const timer = @import("timer.zig");
 const dma = @import("dma.zig");
 const board = microzig.board;
 const font = board.font;
+const terry = @import("../system/terry.zig");
 
 /// Display Configuration
 pub const width: u16 = 160;
@@ -61,6 +62,9 @@ pub fn interrupt_DMA_0() callconv(.c) void {
     const flags = DMA.INTS0.raw;
 
     if (flags & 0b1 != 0) {
+        // TODO this causes a double-end, figure out why. Probably missing volatile on some tracy state.
+        //const z = terry.core0.zone_color_cond("INTERRUPT DMA_0 (LCD)", @src(), 0x00FF7F, terry.client.interrupt_trace_enabled); defer z.end();
+
         if (int_running) {
             board.led_pin.put(1);
         }
@@ -135,6 +139,9 @@ fn write_spi_16_no_flush(data: []const u16) void {
 
 fn flush_spi() void {
     const spi_regs = spi_instance.get_regs();
+
+    const z = terry.core0.fn_zone_cond(@src(), spi_regs.SSPSR.read().BSY != 0); defer z.end();
+
     // Drain RX FIFO, then wait for shifting to finish (which may be *after*
     // TX FIFO drains), then drain RX FIFO again
     while (spi_instance.is_readable()) {
@@ -179,6 +186,8 @@ fn sync_resolve_state(wait_for_transfer: bool) void {
 }
 
 fn wait_for_ready() void {
+    const z = terry.core0.fn_zone_cond(@src(), state.*.is_waiting_for_interrupt()); defer z.end();
+
     while (state.*.is_waiting_for_interrupt()) {}
     sync_resolve_state(true); // force synchronous SPI flush
 }
@@ -341,6 +350,8 @@ pub const Config = struct {
 /// Low-level initialization (control pins only)
 /// Use initWithAllPins() for full initialization including SPI and TE pins
 pub fn init(pin_config: Pins, config: Config) !void {
+    const z = terry.core0.zone("lcd.init", @src()); defer z.end();
+
     pins = pin_config;
 
     // Configure GPIO pins
@@ -399,6 +410,8 @@ pub fn init(pin_config: Pins, config: Config) !void {
 }
 
 fn initDisplay() void {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
+
     // Software reset
     writeCommand(.SWRESET);
     timer.sleep_ms(50);
@@ -470,6 +483,8 @@ fn initDisplay() void {
 /// Re-initialize display registers (call after cart stops to restore LCD settings)
 /// This performs a quick reinit without full hardware reset for faster recovery
 pub fn reinitDisplay() void {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
+
     // Reconfigure critical GPIO pins (cart may have changed them)
     pins.cs.set_function(.sio);
     pins.cs.set_direction(.out);
@@ -572,6 +587,8 @@ pub fn fillScreen(color: Color16) void {
 pub fn fillRect(x: u16, y: u16, w: u16, h: u16, color: Color16) void {
     if (x >= width or y >= height) return;
 
+    const z = terry.core0.fn_zone_cond(@src(), w * h > 16); defer z.end();
+
     const x_clamped = @min(x, width - 1);
     const y_clamped = @min(y, height - 1);
     const w_actual = @min(w, width - x_clamped);
@@ -670,6 +687,8 @@ pub fn drawChar(x: u16, y: u16, char: u8, color: Color16, bg_color: Color16, siz
 }
 
 pub fn drawString(x: u16, y: u16, text: []const u8, color: Color16, bg_color: Color16, size: u8) void {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
+
     var cursor_x = x;
     for (text) |char| {
         drawChar(cursor_x, y, char, color, bg_color, size);
@@ -685,6 +704,8 @@ pub fn drawImageClipped(x: i32, y: i32, w: u32, h: u32, data: [*]const Color16, 
     if (bottom < 0) return; // Offscreen top
     if (y >= height) return; // Offscreen bottom
     if (w == 0 or h == 0) return; // No Area
+
+    const z = terry.core0.fn_zone(@src()); defer z.end();
 
     var start = data;
     var draw_width = w;
@@ -737,6 +758,8 @@ pub fn drawImageClipped(x: i32, y: i32, w: u32, h: u32, data: [*]const Color16, 
 /// Direct buffer writing (for framebuffer updates)
 pub fn writeBuffer(x: u16, y: u16, w: u16, h: u16, buffer: []const u16) void {
     if (x >= width or y >= height) return;
+
+    const z = terry.core0.fn_zone(@src()); defer z.end();
 
     const x1 = @min(x + w - 1, width - 1);
     const y1 = @min(y + h - 1, height - 1);

--- a/src/os/drivers/microzig_rtt.zig
+++ b/src/os/drivers/microzig_rtt.zig
@@ -1,0 +1,592 @@
+/// Fork of MicroZig's RTT library which adds a few features needed for tracy
+const std = @import("std");
+const microzig = @import("microzig");
+const timer = @import("timer.zig");
+
+fn memory_barrier() void {
+    microzig.cpu.dmb();
+    asm volatile ("" ::: .{ .memory = true });
+}
+
+/// Header that indicates to the connected probe how many up/down channels are in use.
+///
+/// The RTT header is found based on the string "SEGGER RTT", so we need to avoid storing
+/// the whole string in memory anywhere other than this header (otherwise host software
+/// may choose the wrong location). Storing it reversed in the variable "init_str" and then
+/// copying it over accomplishes this.
+pub const Header = extern struct {
+    id: [16]u8,
+    max_up_channels: usize,
+    max_down_channels: usize,
+
+    pub fn init(self: *Header, comptime max_up_channels: usize, comptime max_down_channels: usize) void {
+        self.max_up_channels = max_up_channels;
+        self.max_down_channels = max_down_channels;
+
+        const init_str = "\x00\x00\x00\x00\x00\x00TTR REGGES";
+
+        std.mem.doNotOptimizeAway(self);
+
+        // Ensure no memory reordering can occur and all accesses are finished before
+        // marking block "valid" and writing header string. This prevents the JLINK
+        // from finding a "valid" block while offets/pointers aren't yet valid.
+        memory_barrier();
+        for (0..init_str.len) |i| {
+            self.id[i] = init_str[init_str.len - i - 1];
+        }
+        memory_barrier();
+    }
+};
+
+pub const channel = struct {
+    pub const Mode = enum(usize) {
+        NoBlockSkip = 0,
+        NoBlockTrim = 1,
+        BlockIfFull = 2,
+        _,
+    };
+
+    /// Configuration for an up or down channel per the RTT spec
+    pub const Config = struct {
+        name: [*:0]const u8,
+        buffer_size: usize,
+        mode: Mode,
+    };
+
+    /// Represents a target -> host communication channel.
+    ///
+    /// Implements a ring buffer of size - 1 bytes, as this implementation
+    /// does not fill up the buffer in order to avoid the problem of being unable to
+    /// distinguish between full and empty.
+    pub const Up = extern struct {
+        /// Name is optional and is not required by the spec. Standard names so far are:
+        /// "Terminal", "SysView", "J-Scope_t4i4"
+        name: [*:0]const u8,
+
+        buffer: [*]u8,
+
+        /// Note from above actual buffer size is size - 1 bytes
+        size: usize,
+
+        write_offset: usize,
+        raw_read_offset: usize,
+
+        /// Contains configuration flags. Flags[31:24] are used for validity check and must be zero.
+        /// Flags[23:2] are reserved for future use. Flags[1:0] = RTT operating mode.
+        flags: usize,
+
+        const Self = @This();
+
+        fn init(
+            self: *Self,
+            name: [*:0]const u8,
+            buffer: []u8,
+            mode_: Mode,
+        ) void {
+            self.name = name;
+            self.size = buffer.len;
+            self.set_mode(mode_);
+            self.write_offset = 0;
+            self.raw_read_offset = 0;
+
+            std.mem.doNotOptimizeAway(self);
+            std.mem.doNotOptimizeAway(buffer);
+
+            // Ensure buffer pointer is set last and can't be reordered
+            memory_barrier();
+            self.buffer = buffer.ptr;
+        }
+
+        pub fn mode(self: *Self) Mode {
+            return std.meta.intToEnum(Mode, self.flags & 3) catch unreachable;
+        }
+
+        pub fn set_mode(self: *Self, mode_: Mode) void {
+            self.flags = (self.flags & ~@as(usize, 3)) | @intFromEnum(mode_);
+        }
+
+        pub fn load_read_offset(self: *Self) usize {
+            return @as(*volatile usize, &self.raw_read_offset).*;
+        }
+
+        /// Writes up to available space left in buffer for reading by probe, returning number of bytes
+        /// written.
+        pub fn write_available(self: *Self, bytes: []const u8) usize {
+            var c = self.cursor();
+            const written = c.write_available(bytes);
+            if (written != 0) {
+                c.commit();
+            }
+            return written;
+        }
+
+        pub fn write_assume_available(self: *Self, bytes: []const u8) void {
+            var c = self.cursor();
+            c.write_assume_available(bytes);
+            c.commit();
+        }
+
+        /// Blocks until all bytes are written to buffer
+        pub fn write_blocking(self: *Self, bytes: []const u8) usize {
+            const count = bytes.len;
+            var written: usize = 0;
+            while (written != count) {
+                written += self.write_available(bytes[written..]);
+            }
+            return count;
+        }
+
+        pub fn write_blocking_with_deadline(self: *Self, bytes: []const u8, deadline: u64) !void {
+            const count = bytes.len;
+            var written: usize = 0;
+            while (written != count) {
+                const this_write = self.write_available(bytes[written..]);
+                written += this_write;
+                if (this_write == 0 and timer.micros() > deadline) {
+                    return error.Timeout;
+                }
+            }
+        }
+
+        pub fn write_if_available(self: *Self, buf: []const u8) bool {
+            if (self.available_space() >= buf.len) {
+                self.write_assume_available(buf);
+                return true;
+            }
+            return false;
+        }
+
+        /// Behavior depends on up channel's mode, attempts to write all
+        /// bytes to the RTT control block, and returns how many it successfully wrote.
+        /// Writing less than requested number of bytes is not an error.
+        pub fn write(self: *Self, bytes: []const u8) usize {
+            return switch (self.mode()) {
+                .NoBlockSkip => if (self.write_if_available(bytes)) bytes.len else 0,
+                .NoBlockTrim => self.write_available(bytes),
+                .BlockIfFull => self.write_blocking(bytes),
+                _ => unreachable,
+            };
+        }
+
+        /// Available space in the ring buffer for writing, including wrap-around
+        pub fn available_space(self: *Self) usize {
+            // The probe can change self.read_offset via memory modification at any time,
+            // so must perform a volatile read on this value.
+            const read_offset = self.load_read_offset();
+
+            if (read_offset <= self.write_offset) {
+                return self.size - 1 - (self.write_offset - read_offset);
+            } else {
+                return read_offset - self.write_offset - 1;
+            }
+        }
+
+        /// A cursor is used to transactionally put data into the buffer, in case an
+        /// operation may fail. The writes are not made available to the reader
+        /// until commit() is called. If commit() is never called, the data
+        /// will never be made available. Only one cursor can be used at a time, and the
+        /// channel must not be written at all while a cursor is active.
+        pub fn cursor(self: *Self) Cursor {
+            return .init(self);
+        }
+
+        pub const Cursor = struct {
+            chan: *Up,
+            write_pos: usize,
+
+            pub fn init(chan: *Up) Cursor {
+                const offset = chan.write_offset;
+                return .{
+                    .chan = chan,
+                    .write_pos = offset,
+                };
+            }
+
+            pub fn write_byte_assume_available(c: *Cursor, byte: u8) void {
+                c.chan.buffer[c.write_pos] = byte;
+                c.write_pos += 1;
+                if (c.write_pos == c.chan.size) c.write_pos = 0;
+            }
+
+            pub fn write_assume_available(c: *Cursor, bytes: []const u8) void {
+                var write_offset = c.write_pos;
+                const first_write = @min(c.chan.size - write_offset, bytes.len);
+                @memcpy(c.chan.buffer[write_offset .. write_offset + first_write], bytes[0..first_write]);
+                write_offset += first_write;
+                if (first_write < bytes.len) {
+                    @memcpy(c.chan.buffer[0 .. bytes.len - first_write], bytes[first_write..]);
+                    write_offset = bytes.len - first_write;
+                }
+                if (write_offset >= c.chan.size) write_offset = 0;
+                c.write_pos = write_offset;
+            }
+
+            pub fn get_available(c: *Cursor) usize {
+                const read_offset = c.chan.load_read_offset();
+
+                if (read_offset <= c.write_pos) {
+                    return c.chan.size - 1 - (c.write_pos - read_offset);
+                } else {
+                    return read_offset - c.write_pos - 1;
+                }
+            }
+
+            pub fn write_available(c: *Cursor, bytes: []const u8) usize {
+                const available = c.get_available();
+                if (available == 0) return 0;
+
+                const to_write = @min(bytes.len, available);
+                c.write_assume_available(bytes[0..to_write]);
+
+                return to_write;
+            }
+
+            pub fn write_if_available(c: *Cursor, buf: []const u8) bool {
+                if (c.available_space() >= buf.len) {
+                    c.write_assume_available(buf);
+                    return true;
+                }
+                return false;
+            }
+
+            pub fn commit(c: *const Cursor) void {
+                std.mem.doNotOptimizeAway(c.chan);
+                std.mem.doNotOptimizeAway(c.chan.buffer);
+                memory_barrier();
+                @atomicStore(usize, &c.chan.write_offset, c.write_pos, .seq_cst);
+            }
+        };
+
+        /// Implements the std.Io.Writer interface
+        pub const Writer = struct {
+            up_channel: *Self,
+            interface: std.Io.Writer,
+
+            fn init(uc: *Self, buf: []u8) Writer {
+                return .{
+                    .up_channel = uc,
+                    .interface = .{
+                        .vtable = &.{
+                            .drain = drain,
+                        },
+                        .buffer = buf,
+                        .end = 0,
+                    },
+                };
+            }
+
+            /// Implements drain for the Io.Writer interface. Note that this will drop data if it can't all fit
+            /// in the RTT Up channel buffer. This is to prevent constantly returning a WriteError when a debug
+            /// probe isn't connected.
+            ///
+            /// TODO: build.zig option that allows users to opt-in to returning WriteError on full RTT buffer?
+            fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+                const up: *Self = @as(*Writer, @alignCast(@fieldParentPtr("interface", io_w))).up_channel;
+
+                const buffered = io_w.buffered();
+                if (buffered.len > 0) {
+                    _ = up.write_if_available(buffered);
+                    _ = io_w.consumeAll();
+                }
+                var n: usize = 0;
+                for (data[0 .. data.len - 1]) |d| {
+                    _ = up.write_if_available(d);
+                    n += d.len;
+                }
+                for (0..splat) |_| {
+                    const to_splat = data[data.len - 1];
+                    _ = up.write_if_available(to_splat);
+                    n += to_splat.len;
+                }
+                return n;
+            }
+        };
+
+        pub fn writer(uc: *Self, buf: []u8) Writer {
+            return Writer.init(uc, buf);
+        }
+    };
+
+    /// Represents a host -> target communication channel.
+    ///
+    /// Implements a ring buffer of size - 1 bytes, as this implementation
+    /// does not fill up the buffer in order to avoid the problem of being unable to
+    /// distinguish between full and empty.
+    pub const Down = extern struct {
+        /// Name is optional and is not required by the spec. Standard names so far are:
+        /// "Terminal", "SysView", "J-Scope_t4i4"
+        name: [*:0]const u8,
+
+        buffer: [*]u8,
+
+        /// Note from above actual buffer size is size - 1 bytes
+        size: usize,
+
+        write_offset: usize,
+        read_offset: usize,
+
+        /// Contains configuration flags. Flags[31:24] are used for validity check and must be zero.
+        /// Flags[23:2] are reserved for future use. Flags[1:0] = RTT operating mode.
+        flags: usize,
+
+        const Self = @This();
+
+        pub fn init(
+            self: *Self,
+            name: [*:0]const u8,
+            buffer: []u8,
+            mode_: Mode,
+        ) void {
+            self.name = name;
+            self.size = buffer.len;
+            self.set_mode(mode_);
+            self.write_offset = 0;
+            self.read_offset = 0;
+
+            std.mem.doNotOptimizeAway(self);
+            std.mem.doNotOptimizeAway(buffer);
+
+            // Ensure buffer pointer is set last and can't be reordered
+            memory_barrier();
+            self.buffer = buffer.ptr;
+        }
+
+        pub fn mode(self: *Self) Mode {
+            return std.meta.intToEnum(Mode, self.mode & 3);
+        }
+
+        pub fn set_mode(self: *Self, mode_: Mode) void {
+            self.flags = (self.flags & ~@as(usize, 3)) | @intFromEnum(mode_);
+        }
+
+        /// Reads up to a number of bytes from probe non-blocking. Reading less than the requested number of bytes
+        /// is not an error.
+        ///
+        /// TODO: Does the channel's mode actually matter here?
+        pub fn read_available(self: *Self, bytes: []u8) usize {
+            // The probe can change self.write_offset via memory modification at any time,
+            // so must perform a volatile read on this value.
+            const write_offset = @as(*volatile usize, @ptrCast(&self.write_offset)).*;
+            var read_offset = self.read_offset;
+
+            var bytes_read: usize = 0;
+            // Read from current read position to wrap-around of buffer, first
+            if (read_offset > write_offset) {
+                const count = @min(self.size - read_offset, bytes.len);
+                @memcpy(bytes[0..count], self.buffer[read_offset .. read_offset + count]);
+                bytes_read += count;
+                read_offset += count;
+
+                // Handle wrap-around
+                if (read_offset >= self.size) read_offset = 0;
+            }
+
+            // We've now either wrapped around or were wrapped around to begin with
+            if (read_offset < write_offset) {
+                const remaining_bytes = @min(write_offset - read_offset, bytes[bytes_read..].len);
+                // Read remaining items of buffer
+                if (remaining_bytes > 0) {
+                    @memcpy(bytes[bytes_read .. bytes_read + remaining_bytes], self.buffer[read_offset .. read_offset + remaining_bytes]);
+                    bytes_read += remaining_bytes;
+                    read_offset += remaining_bytes;
+                }
+            }
+
+            // Force data write to be complete before writing the read_offset, in case CPU
+            // is allowed to change the order of memory accesses
+            memory_barrier();
+            self.read_offset = read_offset;
+
+            return bytes_read;
+        }
+
+        /// Number of bytes from probe available in ring buffer.
+        pub fn bytes_available(self: *Self) usize {
+
+            // The probe can change self.write_offset via memory modification at any time,
+            // so must perform a volatile read on this value.
+            const write_offset = @as(*volatile usize, @ptrCast(&self.write_offset)).*;
+            if (self.read_offset > write_offset) {
+                return self.size - self.read_offset + write_offset;
+            } else {
+                return write_offset - self.read_offset;
+            }
+        }
+
+        pub fn read_if_available(self: *Self, buf: []u8) bool {
+            // TODO OPT: we can do fewer volatile reads here by merging these functions,
+            // but for now this is fast enough.
+            if (self.bytes_available() >= buf.len) {
+                const bytes_read = self.read_available(buf);
+                std.debug.assert(bytes_read == buf.len);
+                return true;
+            }
+            return false;
+        }
+
+        /// Implements the std.Io.Reader interface
+        pub const Reader = struct {
+            down_channel: *Self,
+            interface: std.Io.Reader,
+
+            fn init(dc: *Self, buf: []u8) Reader {
+                return .{
+                    .down_channel = dc,
+                    .interface = .{
+                        .vtable = &.{
+                            .stream = stream,
+
+                            // Default discarding behavior is acceptable, and will still work even with a zero
+                            // length buffer
+                            .discard = std.Io.Reader.defaultDiscard,
+
+                            // The default behavior prioritizes reading entire internal buffers worth of data rather
+                            // than directly calling RTT reads individually, which is exactly what is desired
+                            .readVec = std.Io.Reader.defaultReadVec,
+
+                            // The default rebase behavior of moving data back to the start of the internal buffer
+                            // is acceptable
+                            .rebase = std.Io.Reader.defaultRebase,
+                        },
+                        .buffer = buf,
+                        .end = 0,
+                        .seek = 0,
+                    },
+                };
+            }
+
+            /// Fetches new data directly from the RTT ring buffer
+            fn stream(io_r: *std.Io.Reader, io_w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+                const down: *Self = @as(*Reader, @alignCast(@fieldParentPtr("interface", io_r))).down_channel;
+                const dest = limit.slice(try io_w.writableSliceGreedy(1));
+                if (down.bytes_available() == 0) return error.EndOfStream;
+                const n = down.read_available(dest);
+                io_w.advance(n);
+                return n;
+            }
+        };
+
+        pub fn reader(self: *Self, buffer: []u8) Reader {
+            return Reader.init(self, buffer);
+        }
+    };
+};
+
+/// Constructs a struct type where each field is a u8 array of size specified by channel config.
+///
+/// Fields follow the naming convention "up_buffer_N" for up channels, and "down_buffer_N" for down channels.
+fn BuildBufferStorageType(comptime up_channels: []const channel.Config, comptime down_channels: []const channel.Config) type {
+    const fields: []const std.builtin.Type.StructField = comptime v: {
+        var fields_temp: [up_channels.len + down_channels.len]std.builtin.Type.StructField = undefined;
+        for (up_channels, 0..) |up_cfg, idx| {
+            const buffer_type = [up_cfg.buffer_size]u8;
+            fields_temp[idx] = .{
+                .name = std.fmt.comptimePrint("up_buffer_{d}", .{idx}),
+                .type = buffer_type,
+                .is_comptime = false,
+                .alignment = @alignOf(buffer_type),
+                .default_value_ptr = null,
+            };
+        }
+        for (down_channels, 0..) |down_cfg, idx| {
+            const buffer_type = [down_cfg.buffer_size]u8;
+            fields_temp[up_channels.len + idx] = .{
+                .name = std.fmt.comptimePrint("down_buffer_{d}", .{idx}),
+                .type = buffer_type,
+                .is_comptime = false,
+                .alignment = @alignOf(buffer_type),
+                .default_value_ptr = null,
+            };
+        }
+        break :v &fields_temp;
+    };
+
+    return @Type(.{
+        .@"struct" = .{
+            .layout = .@"extern",
+            .fields = fields,
+            .decls = &[_]std.builtin.Type.Declaration{},
+            .is_tuple = false,
+        },
+    });
+}
+
+/// Creates a control block struct for the given channel configs. Buffer storage is also contained within this struct, although
+/// per the RTT spec it doesn't have to be.
+fn ControlBlock(comptime up_channels: []const channel.Config, comptime down_channels: []const channel.Config) type {
+    if (up_channels.len == 0 or down_channels.len == 0) {
+        @compileError("Must have at least 1 up and down channel configured");
+    }
+
+    const BufferContainerType = BuildBufferStorageType(up_channels, down_channels);
+    return extern struct {
+        header: Header,
+        up_channels: [up_channels.len]channel.Up,
+        down_channels: [down_channels.len]channel.Down,
+        buffers: BufferContainerType,
+
+        pub fn init(self: *@This()) void {
+            comptime var i: usize = 0;
+
+            std.mem.doNotOptimizeAway(self);
+
+            inline while (i < up_channels.len) : (i += 1) {
+                self.up_channels[i].init(
+                    up_channels[i].name,
+                    &@field(self.buffers, std.fmt.comptimePrint("up_buffer_{d}", .{i})),
+                    up_channels[i].mode,
+                );
+            }
+            i = 0;
+            inline while (i < down_channels.len) : (i += 1) {
+                self.down_channels[i].init(
+                    down_channels[i].name,
+                    &@field(self.buffers, std.fmt.comptimePrint("down_buffer_{d}", .{i})),
+                    down_channels[i].mode,
+                );
+            }
+            // Prevent compiler from re-ordering header init function as it must come last
+            memory_barrier();
+            self.header.init(up_channels.len, down_channels.len);
+        }
+    };
+}
+
+/// Compile time configuration of RTT instance
+pub const Config = struct {
+    up_channels: []const channel.Config = &[_]channel.Config{.{ .name = "Terminal", .buffer_size = 1024, .mode = .NoBlockSkip }},
+    down_channels: []const channel.Config = &[_]channel.Config{.{ .name = "Terminal", .buffer_size = 16, .mode = .BlockIfFull }},
+    /// Optionally place the RTT control block (and buffers) in a specific linker section
+    linker_section: ?[]const u8 = null,
+};
+
+/// Creates an RTT namespace given the compile time configuration with functions for writing/reading from RTT channels.
+pub fn RTT(comptime config: Config) type {
+    return struct {
+        const mb_fn = config.memory_barrier_fn orelse memory_barrier.empty_memory_barrier;
+        var control_block: ControlBlock(
+            config.up_channels,
+            config.down_channels,
+        ) = undefined;
+
+        comptime {
+            @export(&control_block, .{
+                .name = "RttControlBlock",
+                .section = config.linker_section,
+            });
+        }
+
+        /// Initialize RTT, must be called prior to calling any other API functions
+        pub fn init() void {
+            control_block.init();
+        }
+
+        pub fn up_channel(channel_number: usize) *channel.Up {
+            return &control_block.up_channels[channel_number];
+        }
+
+        pub fn down_channel(channel_number: usize) *channel.Down {
+            return &control_block.down_channels[channel_number];
+        }
+    };
+}

--- a/src/os/drivers/rtt.zig
+++ b/src/os/drivers/rtt.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const rtt = @import("microzig_rtt.zig");
+
+const rtt_instance = rtt.RTT(.{
+    .up_channels = &.{
+        .{ .name = "TracySend", .buffer_size = tracy_send_size, .mode = .BlockIfFull },
+        .{ .name = "Logger", .buffer_size = 2048, .mode = .BlockIfFull },
+    },
+    .down_channels = &.{
+        .{ .name = "TracyRecv", .buffer_size = 256, .mode = .BlockIfFull },
+    },
+    .linker_section = ".bss",
+});
+
+pub const tracy_send_size = 2048 * 4;
+pub const tracy_send = rtt_instance.up_channel(0);
+pub const tracy_recv = rtt_instance.down_channel(0);
+
+const log_send = rtt_instance.up_channel(1);
+
+pub fn init() void {
+    rtt_instance.init();
+    rtt_initialized();
+    log_core0("\n\n======================== Rebooted ==========================\n\n");
+}
+
+pub fn log_core0(string: []const u8) void {
+    const cs = microzig.interrupt.enter_critical_section();
+    defer cs.leave();
+
+    _ = log_send.write_if_available(string);
+}
+
+pub fn logf_core0(comptime fmt: []const u8, args: anytype) void {
+    const cs = microzig.interrupt.enter_critical_section();
+    defer cs.leave();
+
+    var writer = log_send.writer(&.{});
+    writer.interface.print(fmt, args) catch {};
+    writer.interface.flush() catch {};
+}
+
+// Debugger can set a breakpoint here to pick up
+// as soon as rtt is initialized.
+noinline fn rtt_initialized() void {
+    asm volatile ("");
+}
+

--- a/src/os/drivers/rtt.zig
+++ b/src/os/drivers/rtt.zig
@@ -5,7 +5,7 @@ const rtt = @import("microzig_rtt.zig");
 const rtt_instance = rtt.RTT(.{
     .up_channels = &.{
         .{ .name = "TracySend", .buffer_size = tracy_send_size, .mode = .BlockIfFull },
-        .{ .name = "Logger", .buffer_size = 2048, .mode = .BlockIfFull },
+        .{ .name = "Logger", .buffer_size = 2048, .mode = .NoBlockSkip },
     },
     .down_channels = &.{
         .{ .name = "TracyRecv", .buffer_size = 256, .mode = .BlockIfFull },

--- a/src/os/drivers/timer.zig
+++ b/src/os/drivers/timer.zig
@@ -9,6 +9,8 @@ const system_timer = hal.system_timer;
 const timer0 = system_timer.num(0);
 pub const Absolute = time.Absolute;
 
+const terry = @import("../system/terry.zig");
+
 // -----------------------------------------------------------------------------
 // Time utilities
 // -----------------------------------------------------------------------------
@@ -23,6 +25,8 @@ pub fn sleep_ms(time_ms: u32) void {
 
 /// Sleep for microseconds (blocking)
 pub fn sleep_us(time_us: u64) void {
+    const z = terry.core0.zone_color_cond("Sleep", @src(), 0x6f6f6f, time_us > 500); defer z.end();
+
     const end_time = time.make_timeout_us(get_time_since_boot(), time_us);
     while (!end_time.is_reached_by(get_time_since_boot())) {}
 }

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -471,6 +471,8 @@ pub fn main() !void {
 
 /// Compute a simple hash of cart list to detect changes
 fn computeCartHash() u32 {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
+
     cart_hash_accumulator = 0;
     storage.listCarts(hashCart);
     return cart_hash_accumulator;
@@ -488,6 +490,8 @@ fn hashCart(name: []const u8, size: u32) void {
 
 /// Refresh the cart list display on LCD
 fn refreshCartDisplay() void {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
+
     const backlight_enable_pin = board.BKLT_PWM;
     backlight_enable_pin.set_function(.sio);
     backlight_enable_pin.set_direction(.out);
@@ -583,6 +587,8 @@ fn collectCartName(name: []const u8, size: u32) void {
 /// Run the currently selected cart
 fn runSelectedCart() void {
     if (cursor_index >= cart_count) return;
+
+    const z = terry.core0.fn_zone(@src()); defer z.end();
 
     const name = cart_names[cursor_index][0..cart_name_lengths[cursor_index]];
     console.printf("[BTN] runSelectedCart: loading '{s}'\r\n", .{name});

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -11,12 +11,14 @@ const gpio = @import("drivers/gpio.zig");
 const audio = @import("drivers/audio.zig");
 const dma = @import("drivers/dma.zig");
 const rev = @import("drivers/rev.zig");
+const rtt = @import("drivers/rtt.zig");
 const console = @import("system/console.zig");
 const init = @import("system/init.zig");
 const fps_overlay = @import("system/fps_overlay.zig");
 const storage = @import("loader/storage.zig");
 const loader = @import("loader/loader.zig");
 const multicore = @import("system/multicore.zig");
+const terry = @import("system/terry.zig");
 const mailbox = @import("ipc/mailbox.zig");
 
 // Use panic handler from system
@@ -85,6 +87,9 @@ const BTN_DIAG_US: u64 = 2_000_000; // 2 seconds
 var btn_diag_last_us: u64 = 0;
 var btn_diag_cart_was_running: bool = false; // tracks first-run edge
 
+const EARLY_TRACY_WAIT_TIME_US = 0;
+const LATE_TRACY_WAIT_TIME_US = 0; // 60_000_000 * 10; // 10 minutes
+
 // Button state tracking
 var joystick_up_was_pressed: bool = false;
 var joystick_down_was_pressed: bool = false;
@@ -134,6 +139,8 @@ pub fn main() !void {
         .lcd_pins = lcd.createDT018BTFTPins(),
         .lcd_config = lcd.createDT018BTFTConfig(),
         .init_core1 = true,
+        .early_wait_for_tracy_time = EARLY_TRACY_WAIT_TIME_US,
+        .late_wait_for_tracy_time = LATE_TRACY_WAIT_TIME_US,
     });
 
     // Initialize button poller
@@ -162,6 +169,8 @@ pub fn main() !void {
         usb.poll();
 
         audio.poll();
+
+        terry.client.poll();
 
         fps_overlay.poll();
 

--- a/src/os/system/fps_overlay.zig
+++ b/src/os/system/fps_overlay.zig
@@ -5,6 +5,7 @@ const badge = microzig.board;
 const lcd = @import("../drivers/lcd.zig");
 const timer = @import("../drivers/timer.zig");
 const rev = @import("../drivers/rev.zig");
+const terry = @import("terry.zig");
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -230,6 +231,8 @@ pub fn poll() void {
 pub fn submit_lcd_work() void {
     // Tick the display state machine
     if (curr_debug_text < num_debug_texts) {
+        const z = terry.core0.zone("fps_overlay.submit_lcd_work", @src()); defer z.end();
+
         const curr = &debug_texts[curr_debug_text];
         // Render the text
         draw_str(curr.str[0..curr.len], &debug_img, debug_pitch, curr.fg_color, curr.bg_color);
@@ -248,6 +251,8 @@ fn update_debug_text() void {
     reset_debug_text();
 
     if (!enabled) return;
+
+    const z = terry.core0.zone("fps_overlay.update_debug_text", @src()); defer z.end();
 
     // Yellow text on black.
     // Right-justify the FPS value in 3 characters

--- a/src/os/system/fps_overlay.zig
+++ b/src/os/system/fps_overlay.zig
@@ -187,13 +187,12 @@ pub fn tick() void {
     update_debug_text();
 }
 
-pub fn submit_audio_mix_time(start: u64, end: u64, req: u64) void {
-    const service_delay: u32 = time_delta(req, start);
+pub fn submit_audio_mix_time(start: u64, end: u64, max_poll_time: u32) void {
     const mix_time: u32 = time_delta(start, end);
     audio_mix_count += 1;
     audio_mix_total_us += mix_time;
     audio_mix_max_us = @max(audio_mix_max_us, mix_time);
-    audio_service_delay_max_us = @max(audio_service_delay_max_us, service_delay);
+    audio_service_delay_max_us = @max(audio_service_delay_max_us, max_poll_time);
 }
 
 pub fn poll() void {
@@ -290,7 +289,7 @@ fn update_debug_text() void {
     add_debug_text(.{ .text = audio_time_str, .x = 0, .y = 8, .alignment = .left, .color = lcd.BLUE });
 
     if (display_max_audio_delay != 0) {
-        const audio_delay_str = std.fmt.bufPrint(&buf, "{d:>4}", .{display_max_audio_delay}) catch "!!!!";
+        const audio_delay_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{poll_max_max * 100 / display_max_audio_delay}) catch "!!!%";
         add_debug_text(.{ .text = audio_delay_str, .x = 4*font_width, .y = 0, .alignment = .left, .color = lcd.RED });
     }
 

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -144,6 +144,8 @@ pub fn init(config: InitConfig) !void {
         _ = terry.client.wait_for_connection(deadline) catch {};
     }
 
+    const z = terry.core0.zone("Initialize", @src()); defer z.end();
+
     // 0. Detect board revision
     rev.init();
 

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -15,6 +15,8 @@ const rom = @import("../drivers/rom.zig");
 const loader = @import("../loader/loader.zig");
 const debug_log = @import("../debug_log.zig");
 const rev = @import("../drivers/rev.zig");
+const rtt = @import("../drivers/rtt.zig");
+const terry = @import("../system/terry.zig");
 
 // System imports
 const console = @import("console.zig");
@@ -109,6 +111,16 @@ pub const InitConfig = struct {
 
     /// Custom entrypoint for Core 1 (if null, uses default cart.main)
     core1_entrypoint: ?*const fn () void = null,
+
+    /// Amount of time to wait for a Tracy server to connect before running
+    /// any initialization. This will look like a stall if you don't know
+    /// it's coming.
+    early_wait_for_tracy_time: u64 = 0,
+
+    /// Amount of time to wait for a tracy server to connect after initialization
+    /// but before the main loop starts. This will display a nice message on
+    /// the screen telling the user that it's waiting.
+    late_wait_for_tracy_time: u64 = 0,
 };
 
 /// Initialize all drivers and kernel systems
@@ -124,6 +136,13 @@ pub fn init(config: InitConfig) !void {
     clearOnBoot();
     // Copy RAM-resident flash helpers before any flash writes.
     copyRamTextSection();
+
+    // -1. Set up RTT and terry for monitoring initialization
+    rtt.init();
+    if (config.early_wait_for_tracy_time != 0) {
+        const deadline = timer.micros() + config.early_wait_for_tracy_time;
+        _ = terry.client.wait_for_connection(deadline) catch {};
+    }
 
     // 0. Detect board revision
     rev.init();
@@ -180,7 +199,26 @@ pub fn init(config: InitConfig) !void {
         }
     }
 
-    // 11. Initialize Core 1 if chosen (should always be chosen in practice)
+    // 11. Wait for late tracy connection after initialization, with friendly screen message
+    if (config.late_wait_for_tracy_time != 0 and terry.client.is_waiting_for_connection()) {
+        const deadline = timer.micros() + config.late_wait_for_tracy_time;
+        lcd.clearScreen(lcd.BLACK);
+        while (lcd.isBusy() and terry.client.is_waiting_for_connection()) {
+            terry.client.poll();
+        }
+        while (lcd.isBusy()) {}
+        const msg = "Waiting for Tracy";
+        lcd.drawString(@intCast(lcd.width/2 - (msg.len * 4)), lcd.height/2 - 4, msg, lcd.CYAN, lcd.BLACK, 1);
+        if (terry.client.is_waiting_for_connection()) {
+            while (true) {
+                terry.client.poll();
+                if (!terry.client.is_waiting_for_connection()) break;
+                if (timer.millis() > deadline) break;
+            }
+        }
+    }
+
+    // 12. Initialize Core 1 if chosen (should always be chosen in practice)
     if (config.init_core1) {
         if (config.core1_entrypoint) |entrypoint| {
             multicore.initCore1WithEntrypoint(entrypoint);

--- a/src/os/system/terry.zig
+++ b/src/os/system/terry.zig
@@ -1,0 +1,250 @@
+pub const client = @import("terry_client.zig");
+const q = @import("terry_protocol.zig");
+
+const mz_rtt = @import("../drivers/microzig_rtt.zig");
+const rtt = @import("../drivers/rtt.zig");
+const timer = @import("../drivers/timer.zig");
+const std = @import("std");
+
+const microzig = @import("microzig");
+
+pub const poll = client.poll;
+
+const external_linksection = ".rodata";
+
+fn StringWrap(comptime str: [:0]const u8) type {
+    return struct {
+        const bytes linksection(external_linksection) = str[0..str.len:0].*;
+    };
+}
+
+inline fn external_string(comptime str: [:0]const u8) [*:0]const u8 {
+    return &StringWrap(str).bytes;
+}
+
+fn SourceLocationWrap(name: ?[:0]const u8, zig_src_loc: std.builtin.SourceLocation, color: u32) type {
+    return struct {
+        pub const src_loc: q.SourceLocationData linksection(external_linksection) = .{
+            .name = if (name) |n| external_string(n) else null,
+            .function = external_string(zig_src_loc.fn_name),
+            .file = external_string(zig_src_loc.file),
+            .line = zig_src_loc.line,
+            .color = color,
+        };
+    };
+}
+
+pub inline fn external_source_location(comptime name: ?[:0]const u8, comptime zig_src_loc: std.builtin.SourceLocation, comptime color: u32) *const q.SourceLocationData {
+    return &SourceLocationWrap(name, zig_src_loc, color).src_loc;
+}
+
+
+pub const ZoneCtxData = struct {
+    pub const inactive: ZoneCtxData = .{ .active = false, .conn_id = undefined };
+
+    active: bool,
+    conn_id: u16,
+};
+
+
+pub const core0 = struct {
+    const interface = struct {
+        pub const is_connected = client.is_connected_core0;
+        pub const get_connection_id = client.get_connection_id_core0;
+
+        pub fn begin(comptime max_segments: usize) Writer(max_segments) {
+            return .init_with_cs();
+        }
+
+        fn Writer(comptime max_segments: usize) type {
+            return struct {
+                start_time_tracy: i64,
+                ref_time: i64,
+                extents: [max_segments][]const u8 = undefined,
+                num_extents: usize = 0,
+                literal_bytes: usize = 0,
+                reserved_space: usize = 0,
+                cs: microzig.interrupt.CriticalSection,
+                thread_ctx_data: q.Packet(q.ThreadContext) = undefined,
+                has_thread_ctx: bool,
+
+                fn init_with_cs() @This() {
+                    const cs = microzig.interrupt.enter_critical_section();
+                    return .{
+                        .cs = cs,
+                        .start_time_tracy = client.get_time_core0(cs),
+                        .ref_time = client.core0_thread_ref_time,
+                        .has_thread_ctx = client.has_core0_thread_context,
+                    };
+                }
+
+                pub fn add_extent(w: *@This(), data: []const u8) void {
+                    std.debug.assert(w.num_extents < max_segments);
+                    w.extents[w.num_extents] = data;
+                    w.num_extents += 1;
+                    w.literal_bytes += data.len;
+                }
+
+                pub fn thread_ctx(w: *@This()) void {
+                    if (!w.has_thread_ctx) {
+                        w.thread_ctx_data = .{ .ty = .ThreadContext, .data = .{ .thread = client.core0_thread_id } };
+                        w.add_extent(std.mem.asBytes(&w.thread_ctx_data));
+                        w.ref_time = 0;
+                        w.has_thread_ctx = true;
+                    }
+                }
+
+                pub fn thread_time(w: *@This()) i64 {
+                    return w.thread_time_at(w.start_time_tracy);
+                }
+
+                pub fn thread_time_at(w: *@This(), time: i64) i64 {
+                    const delta = time - w.ref_time;
+                    w.ref_time = time;
+                    return delta;
+                }
+
+                pub fn commit(w: *@This()) void {
+                    const layout = client.wire_layout(w.literal_bytes);
+                    if (client.send.available_space() >= layout.total_bytes + w.reserved_space) {
+                        var cursor = client.write_header_assume_available(layout);
+                        for (w.extents[0..w.num_extents]) |extent| {
+                            cursor.write_assume_available(extent);
+                        }
+                        cursor.commit();
+
+                        client.has_core0_thread_context = w.has_thread_ctx;
+                        client.core0_thread_ref_time = w.ref_time;
+                    } else {
+                        client.data_overflow(w.start_time_tracy);
+                    }
+                }
+
+                pub fn end(w: *@This()) void {
+                    w.cs.leave();
+                }
+            };
+        }
+    };
+
+    pub const Zone = struct {
+        data: ZoneCtxData,
+
+        pub inline fn end(z: Zone) void {
+            zone_end(z.data);
+        }
+    };
+
+    pub inline fn fn_zone(comptime loc: std.builtin.SourceLocation) Zone {
+        return zone_color_cond(null, loc, 0, true);
+    }
+    pub inline fn fn_zone_color(comptime loc: std.builtin.SourceLocation, comptime color: u32) Zone {
+        return zone_color_cond(null, loc, color, true);
+    }
+    pub inline fn zone(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation) Zone {
+        return zone_color_cond(name, loc, 0, true);
+    }
+    pub inline fn zone_color(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, comptime color: u32) Zone {
+        return zone_color_cond(external_source_location(name, loc, color), true);
+    }
+    pub inline fn fn_zone_cond(comptime loc: std.builtin.SourceLocation, active: bool) Zone {
+        return zone_color_cond(null, loc, 0, active);
+    }
+    pub inline fn fn_zone_color_cond(comptime loc: std.builtin.SourceLocation, comptime color: u32, active: bool) Zone {
+        return zone_color_cond(null, loc, color, active);
+    }
+    pub inline fn zone_cond(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, active: bool) Zone {
+        return zone_color_cond(name, loc, 0, active);
+    }
+    pub inline fn zone_color_cond(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, comptime color: u32, active: bool) Zone {
+        return .{ .data = zone_begin_static(external_source_location(name, loc, color), active) };
+    }
+
+    inline fn zone_begin_static(src_loc: *const q.SourceLocationData, active: bool) ZoneCtxData {
+        // TODO on-demand check connection ID
+        if (!active or !interface.is_connected()) return .inactive;
+
+        const conn_id = outline_zone_begin_static(src_loc);
+        return .{
+            .active = true,
+            .conn_id = conn_id,
+        };
+    }
+
+    noinline fn outline_zone_begin_static(src_loc: *const q.SourceLocationData) u16 {
+        var writer = interface.begin(2);
+        defer writer.end();
+
+        const conn_id = interface.get_connection_id();
+
+        if (client.is_buffer_full()) {
+            client.push_zone(src_loc);
+            _ = client.try_resume_data(writer.start_time_tracy);
+        } else {
+            writer.thread_ctx();
+            var begin_data: q.ZoneBeginData = undefined;
+            writer.add_extent( begin_data.set( writer.thread_time(), src_loc ) );
+            writer.reserved_space = client.reserved_space_for_begin_zone();
+            writer.commit();
+
+            client.push_zone(src_loc);
+        }
+
+        return conn_id;
+    }
+
+    inline fn zone_end(ctx: ZoneCtxData) void {
+        if (!ctx.active or client.core0_num_zones == 0) return;
+
+        // TODO on-demand check connection ID
+        if (!interface.is_connected()) {
+            client.pop_zone();
+            return;
+        }
+
+        outline_zone_end();
+    }
+
+    noinline fn outline_zone_end() void {
+        var writer = interface.begin(2);
+        defer writer.end();
+
+        if (client.is_buffer_full()) {
+            client.pop_zone();
+            _ = client.try_resume_data(writer.start_time_tracy);
+        } else {
+            writer.thread_ctx();
+            var end_data: q.ZoneEndData = undefined;
+            writer.add_extent( end_data.set( writer.thread_time() ) );
+            writer.reserved_space = client.reserved_space_for_end_zone();
+            writer.commit();
+
+            client.pop_zone();
+        }
+    }
+};
+
+pub fn register_parameter_callback(
+    comptime Ctx: type,
+    comptime cb: fn(*Ctx, u32, i32) void,
+    ctx: *Ctx,
+) void {
+    client.param_callback_obj = ctx;
+    client.param_callback_fn = struct {
+        fn param_callback(ptr: ?*anyopaque, param_idx: u32, param_val: u32) void {
+            cb(@ptrCast(ptr), param_idx, param_val);
+        }
+    }.param_callback;
+}
+
+pub fn register_parameter_callback_static(
+    comptime cb: fn(u32, i32) void,
+) void {
+    client.param_callback_obj = null;
+    client.param_callback_fn = struct {
+        fn param_callback_static(ptr: ?*anyopaque, param_idx: u32, param_val: u32) void {
+            _ = ptr;
+            cb(param_idx, param_val);
+        }
+    }.param_callback_static;
+}

--- a/src/os/system/terry_client.zig
+++ b/src/os/system/terry_client.zig
@@ -1,0 +1,1075 @@
+/// Terry is a reimplementation of the Tracy 0.14.0 client designed for a
+/// low-memory threadless microcontroller environment with RTT output.
+
+const terry = @import("terry.zig");
+const q = @import("terry_protocol.zig");
+
+const timer = @import("../drivers/timer.zig");
+const rev = @import("../drivers/rev.zig");
+const rtt = @import("../drivers/rtt.zig");
+const mzrtt = @import("../drivers/microzig_rtt.zig");
+
+const std = @import("std");
+const builtin = @import("builtin");
+const microzig = @import("microzig");
+
+pub const log = rtt.log_core0;
+pub const logf = rtt.logf_core0;
+
+pub const send = rtt.tracy_send;
+const recv = rtt.tracy_recv;
+
+// TODO OS sampling
+/// Frequency with which OS samples are collected, in uS.
+const os_sampling_period: i64 = 0;
+
+// TODO on demand is not implemented yet
+const support_on_demand = false;
+
+const State = enum {
+    uninitialized,
+    wait_for_server,
+    handshake,
+    send_welcome_msg,
+    send_on_demand_payload,
+    new_connection,
+    
+    connected,
+    buffer_full,
+
+    timeout,
+    terminating,
+    bad_protocol_version,
+    unrecoverable_error,
+    terminal,
+};
+
+var tmp_packet: [q.MaxPacketSize]u8 = undefined;
+var tmp_packet_data: []const u8 = undefined;
+fn tmp_packet_as(comptime PacketType: type) *align(1) PacketType {
+    return @ptrCast(&tmp_packet);
+}
+
+const PendingPacket = enum {
+    no_packet,
+    server_query,
+    external_name_pt1,
+    timeout,
+    terminal,
+};
+
+var pending_packet_type: PendingPacket = .no_packet;
+
+var state: State = .uninitialized;
+var startup_time: i64 = 0;
+var last_keep_alive_us: u64 = 0;
+
+// 1 second timeout is probably too large, but for now we want to
+// give the server/host the benefit of the doubt.
+pub const server_timeout_us = 1_000_000;
+
+pub const core0_thread_id = 1;
+pub var core0_thread_ref_time: i64 = 0;
+pub var has_core0_thread_context: bool = false;
+
+pub var interrupt_trace_enabled: bool = false;
+var disconnect_requested: bool = false;
+
+var atomic_connection_id: u16 = 0;
+var atomic_is_connected: bool = false;
+
+pub var param_callback_obj: ?*anyopaque = null;
+pub var param_callback_fn: ?*const fn(?*anyopaque, u32, i32) void = null;
+
+var last_up_read: usize = 0;
+var last_up_write: usize = 0;
+
+const Cursor = mzrtt.channel.Up.Cursor;
+
+pub const WireLayout = struct {
+    total_bytes: usize,
+    header_bytes: usize,
+    lz4_bytes: usize,
+    data_bytes: usize,
+};
+
+fn header_size(literal_bytes: usize) usize {
+    // Fast case for small lengths, which is most of them
+    if (literal_bytes < 15+255) {
+        return 1 + @as(usize, @intFromBool(literal_bytes >= 15));
+    }
+    // 4 bytes compressed len, 1 byte token, ceil(max(0, data_bytes - 15) / 255) bytes len
+    return 1 + (literal_bytes + (255 - 15)) / 255;
+}
+
+fn match_copy_len_bytes(copy_len: usize) usize {
+    // Fast case for small lengths, which is most of them
+    if (copy_len < 19+255) {
+        return @intFromBool(copy_len >= 19);
+    }
+    return (copy_len + (255 - 19)) / 255;
+}
+
+pub inline fn wire_layout(data_bytes: usize) WireLayout {
+    const lz4_header_bytes = header_size(data_bytes);
+    return .{
+        .total_bytes = 4 + lz4_header_bytes + data_bytes,
+        .header_bytes = 4 + lz4_header_bytes,
+        .lz4_bytes = lz4_header_bytes + data_bytes,
+        .data_bytes = data_bytes,
+    };
+}
+
+pub inline fn write_header_assume_available(w: WireLayout) Cursor {
+    var cursor = send.cursor();
+    // 32 bit length
+    var len_32: u32 = @intCast(w.lz4_bytes);
+    cursor.write_assume_available(std.mem.asBytes(&len_32));
+    // encoded LZ4 length
+    cursor.write_byte_assume_available(@as(u8, @min(w.data_bytes, 15)) << 4);
+    if (w.data_bytes >= 15) {
+        var rem = w.data_bytes - 15;
+        while (true) {
+            cursor.write_byte_assume_available(@intCast(@min(rem, 255)));
+            if (rem < 255) break;
+            rem -= 255;
+        }
+    }
+
+    return cursor;
+}
+
+pub fn data_total_len(data: []const []const u8) usize {
+    var data_bytes: usize = 0;
+    for (data) |sub| {
+        data_bytes += sub.len;
+    }
+    return data_bytes;
+}
+
+const core0_max_zones = 64;
+var core0_zones: [core0_max_zones]*const q.SourceLocationData = undefined;
+pub var core0_num_zones: u32 = 0;
+
+pub fn push_zone(srcloc: *const q.SourceLocationData) void {
+    if (core0_num_zones < core0_max_zones) {
+        core0_zones[core0_num_zones] = srcloc;
+    }
+    core0_num_zones += 1;
+}
+
+pub fn pop_zone() void {
+    core0_num_zones -= 1;
+}
+
+/// To emit a bulk end operation, we need an encoded sequence of:
+/// [1 byte ThreadContext + 4 byte threadID] ++ [ 1 byte ZoneEnd64 tag, 8 bytes timestamp] ++ [1 byte ZoneEnd16, 0x00_00] ** N-1 ++ [1 byte ZoneBegin16, 0x00_00, 4 bytes data missing srcloc, 4 bytes zero]
+/// We can take advantage of the LZ4 match-copy for that last repeating chunk, but doing so is a bit tricky because
+/// of historical restrictions on the LZ4 format:
+///  - The last literal must be at least 5 bytes (satisfied by our uncompressible ZoneBegin trailer)
+///  - The last match copy must start at least 12 bytes before the end (satisfied by our ZoneBegin trailer)
+/// And of course the real restriction that match copies must copy at least 4 bytes, which means we need at least two 3-byte ZoneEnd16
+/// zones before we can start a match copy
+/// For 0 zones: 2 byte header + 5+17 uncompressable = 24 bytes
+/// For 1-3 zones: 2 byte header + 14 + 3*(N-1) + 11 bytes uncompressable (LZ4 requires at least 5 bytes in the last literal)
+/// 1: 27, 2: 30, 3: 33
+/// We can encode a match copy in the header up to a length of 18, which means we max out at N=2+18/3=8
+/// For 4-8  zones: 2 byte header + 14 + 3 bytes + 2 byte offset + 1 byte final header + 11 bytes final literal
+/// 4-8: 33 bytes
+/// If we add one byte of matchlen, we can support matchlen up to 254+15+4, for N=2+273/3=93
+/// For 9-93 zones: 2 byte header + 14 + 3 bytes + 2 byte offset + 1 byte matchlen + 1 byte final header + 11 bytes final literal
+/// 9-93: 34 bytes
+/// From there every extra byte adds 85 more depth, extending the match copy by up to 255 more bytes.
+fn compute_bulk_end_max_len(num_zones: u32) usize {
+    var starter_literal_size: usize = 0;
+
+    starter_literal_size += @sizeOf(q.Packet(q.ThreadContext));
+
+    // Special case: With zero zones, we just open a zone for "Data Lost", which is variable sized based on dt.
+    if (num_zones == 0) {
+        starter_literal_size += @sizeOf(q.ZoneBeginData);
+        return wire_layout(starter_literal_size).total_bytes;
+    }
+
+    starter_literal_size += @sizeOf(q.ZoneEndData);
+
+    // With less than 4 zones, we can't meaningfully compress the data. The whole thing is a literal.
+    if (num_zones < 4) {
+        starter_literal_size += (num_zones - 1) * @sizeOf(q.Packet(q.ZoneEnd16)) + @sizeOf(q.Packet(q.ZoneBegin16));
+        return wire_layout(starter_literal_size).total_bytes;
+    }
+
+    // With more than 4 zones, we add one empty packet and then a huge match copy for it.
+    starter_literal_size += @sizeOf(q.Packet(q.ZoneEnd16));
+
+    const bytes_to_copy = @sizeOf(q.Packet(q.ZoneEnd16)) * (num_zones - 2);
+    const ext_copy_bytes = match_copy_len_bytes(bytes_to_copy);
+
+    const starter_header_size = header_size(starter_literal_size);
+    const total_lz4_size: u32 = starter_header_size + starter_literal_size + 2 + ext_copy_bytes + 1 + @sizeOf(q.Packet(q.ZoneBegin16));
+
+    return @sizeOf(u32) + total_lz4_size;
+}
+
+fn core0_emit_bulk_end(time: i64) void {
+    const warning_zone = terry.external_source_location("Data Lost, Too Many Zones!", @src(), 0xcc1100);
+
+    const num_zones = core0_num_zones;
+
+    logf("TERRY: BULK END for {d} zones\n", .{num_zones});
+
+    var starter_literal_size: usize = 0;
+
+    const emit_thread_context = !has_core0_thread_context;
+    var thread_ctx: q.Packet(q.ThreadContext) = undefined;
+    const dt = if (emit_thread_context) blk: {
+        starter_literal_size += @sizeOf(@TypeOf(thread_ctx));
+        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id } };
+        has_core0_thread_context = true;
+        break :blk time;
+    } else time - core0_thread_ref_time;
+    core0_thread_ref_time = time;
+
+    // Special case: With zero zones, we just open a zone for "Data Lost", which is variable sized based on dt.
+    if (num_zones == 0) {
+        var first_begin: q.ZoneBeginData = undefined;
+        const begin_bytes = first_begin.set(dt, warning_zone);
+        starter_literal_size += begin_bytes.len;
+
+        const layout = wire_layout(starter_literal_size);
+        var cursor = write_header_assume_available(layout);
+        if (emit_thread_context) {
+            cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+        }
+        cursor.write_assume_available(begin_bytes);
+        cursor.commit();
+
+        return;
+    }
+
+    var first_end: q.ZoneEndData = undefined;
+    const first_end_bytes = first_end.set(dt);
+    starter_literal_size += first_end_bytes.len;
+
+    const repeat_end = q.packet(.ZoneEnd16, .{ .time = 0 });
+    const begin_error = q.packet(.ZoneBegin16, .{ .time = 0, .srcloc = @intFromPtr(warning_zone) });
+
+
+    // With less than 4 zones, we can't meaningfully compress the data. The whole thing is a literal.
+    if (num_zones < 4) {
+        starter_literal_size += (num_zones - 1) * @sizeOf(@TypeOf(repeat_end)) + @sizeOf(@TypeOf(begin_error));
+
+        const layout = wire_layout(starter_literal_size);
+        var cursor = write_header_assume_available(layout);
+        if (emit_thread_context) {
+            cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+        }
+        cursor.write_assume_available(first_end_bytes);
+        for (1..num_zones) |_| {
+            cursor.write_assume_available(std.mem.asBytes(&repeat_end));
+        }
+        cursor.write_assume_available(std.mem.asBytes(&begin_error));
+        cursor.commit();
+
+        return;
+    }
+
+    // With more than 4 zones, we add one empty packet and then a huge match copy for it.
+    starter_literal_size += @sizeOf(@TypeOf(repeat_end));
+
+    const bytes_to_copy = @sizeOf(@TypeOf(repeat_end)) * (num_zones - 2);
+    const ext_copy_bytes = match_copy_len_bytes(bytes_to_copy);
+
+    const starter_header_size = header_size(starter_literal_size);
+    const total_lz4_size: u32 = starter_header_size + starter_literal_size + 2 + ext_copy_bytes + 1 + @sizeOf(@TypeOf(begin_error));
+
+    const token_high: u8 = @min(15, starter_literal_size);
+    const token_low: u8 = @min(19, bytes_to_copy) - 4;
+    const token = token_high << 4 | token_low;
+
+    var cursor = send.cursor();
+    cursor.write_assume_available(std.mem.asBytes(&total_lz4_size));
+    cursor.write_byte_assume_available(token);
+    if (starter_literal_size >= 15) {
+        var rem = starter_literal_size - 15;
+        while (true) {
+            cursor.write_byte_assume_available(@min(rem, 255));
+            if (rem < 255) break;
+            rem -= 255;
+        }
+    }
+    if (emit_thread_context) {
+        cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+    }
+    cursor.write_assume_available(first_end_bytes);
+    cursor.write_assume_available(std.mem.asBytes(&repeat_end));
+    // 16 bit little endian offset of 3 for the match copy
+    cursor.write_byte_assume_available(@sizeOf(@TypeOf(repeat_end)));
+    cursor.write_byte_assume_available(0);
+    // extended match copy length bytes
+    if (bytes_to_copy >= 19) {
+        var rem = bytes_to_copy - 19;
+        while (true) {
+            cursor.write_byte_assume_available(@min(rem, 255));
+            if (rem < 255) break;
+            rem -= 255;
+        }
+    }
+    // Second and final block: Literal for the start zone. This just needs the token byte
+    cursor.write_byte_assume_available(@intCast(@sizeOf(@TypeOf(begin_error)) << 4));
+    cursor.write_assume_available(std.mem.asBytes(&begin_error));
+    cursor.commit();
+}
+
+pub fn reserved_space_for_begin_zone() usize {
+    return compute_bulk_end_max_len(core0_num_zones + 1);
+}
+
+pub fn reserved_space_for_end_zone() usize {
+    return compute_bulk_end_max_len(@max(1, core0_num_zones) - 1);
+}
+
+/// For a bulk start operation, we have this sequence:
+/// [1 byte ThreadContext + 4 byte threadID] ++ [1 byte ZoneEnd64 tag, 8 bytes timestamp] ++ [1 byte ZoneBegin16, 0x00_00, 4 bytes srcloc, 4 bytes zero] ** N
+///                                        ^5                                           ^5+9=14                                                        ^14+11=25
+/// The srcloc changes for each item, but we can encode the sequence [4 bytes zero, 1 byte ZoneBegin16, 2 bytes zero] as a match copy between the srclocs.
+/// Because of the historical LZ4 requirements, the last literal will always be the [4 bytes srcloc, 4 bytes zero] for the last item
+/// For 0 items: 1 byte header, 14 byte payload
+/// For 1 item: 2 byte header, 25 incompressible + 8 tail = 35 bytes
+/// for 2 items: Compressing would violate 12 byte rule, so 46 bytes
+/// For 3-(max+1), 2 byte header, 25+3 incompressible, 2 offset, [1 header, 4 srcloc, 2 offset] ** N-2, 1 final header, 8 tail = 48-496 bytes
+/// After item (max+1), all of the srclocs are the same value, so we can encode the rest of the sequence as one big match copy.
+/// We must take care to satisfy the historical requirements of 5+ bytes tail and 12+bytes between the dest of the last copy and the end.
+/// At the end of the stream described above, we have
+/// [1 header, 4 srcloc, 2 offset], with the stream containing [... 4 byte 0, 1 byte ZoneBegin16, 0x00_00, 4 deep_srcloc],
+/// which we can then repeat for 11*N-(max+1) bytes before ending with a literal of the MSB of srcloc and 4 bytes of zero
+/// So our whole sequence is:
+/// For (max+2)+, 2 byte header, 25+4 incompressible, 2 offset, [1 header, 4 srcloc, 2 offset] ** (max+1)-2, [1 header, 4 srcloc, 2 offset, ext matchlen], 1 header, 8 tail
+fn compute_bulk_begin_max_len(num_zones: u32) usize {
+    var starter_literal_size: usize = 0;
+    starter_literal_size += @sizeOf(q.Packet(q.ThreadContext));
+    starter_literal_size += @sizeOf(q.ZoneEndData);
+
+    // Special case: With zero zones, we just open a zone for "Data Lost", which is variable sized based on dt.
+    if (num_zones == 0) {
+        return wire_layout(starter_literal_size).total_bytes;
+    }
+
+    starter_literal_size += @sizeOf(q.Packet(q.ZoneBegin16));
+
+    if (num_zones == 1) {
+        return wire_layout(starter_literal_size).total_bytes;
+    }
+
+    starter_literal_size += @sizeOf(q.Packet(q.ZoneBegin16));
+
+    if (num_zones == 2) {
+        return wire_layout(starter_literal_size).total_bytes;
+    }
+
+    starter_literal_size -= 4;
+
+    // The last srcloc will be emitted in a literal tail
+    const tail_size = 9; // 0x80 header, 4 srcloc, 4 zero
+
+    const item_block_size = 1 + 4 + 2; // token 0x43, src_loc 4, 0x000b
+    // -2: 1 for the original begin and one for the tail
+    const repeat_payload_size = @as(u32, @min(num_zones-1, core0_max_zones) - 2) * item_block_size;
+
+    // If we go past the end of the recorded zone stack, emit a repeated "unknown" begin.
+    var error_copy_bytes: usize = 0;
+    var error_repeat_size: usize = 0;
+    if (num_zones > core0_max_zones + 1) {
+        // 7 bytes to align to the next srcloc, plus a full copy for every repeat
+        // -2: 1 for the original literal and 1 for the trailer
+        error_copy_bytes = 7 + (num_zones - core0_max_zones - 2) * @sizeOf(q.Packet(q.ZoneBegin16));
+        error_repeat_size = item_block_size + match_copy_len_bytes(error_copy_bytes);
+    }
+
+    const total_lz4_size: u32 = header_size(starter_literal_size) + starter_literal_size + 2 + repeat_payload_size + error_repeat_size + tail_size;
+
+    return @sizeOf(u32) + total_lz4_size;
+}
+
+fn core0_emit_bulk_begin(time: i64) void {
+    const overflow_zone = terry.external_source_location("Zones Too Deep", @src(), 0x4E3729);
+
+    var starter_literal_size: usize = 0;
+
+    const num_zones = core0_num_zones;
+
+    logf("TERRY: BULK BEGIN for {d} zones\n", .{num_zones});
+
+    const emit_thread_context = !has_core0_thread_context;
+    var thread_ctx: q.Packet(q.ThreadContext) = undefined;
+    const dt = if (emit_thread_context) blk: {
+        starter_literal_size += @sizeOf(@TypeOf(thread_ctx));
+        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id } };
+        has_core0_thread_context = true;
+        break :blk time;
+    } else time - core0_thread_ref_time;
+    core0_thread_ref_time = time;
+
+    var end_data: q.ZoneEndData = undefined;
+    const end_bytes = end_data.set(dt);
+    starter_literal_size += end_bytes.len;
+
+    // Special case: With zero zones, we just open a zone for "Data Lost", which is variable sized based on dt.
+    if (num_zones == 0) {
+        const layout = wire_layout(starter_literal_size);
+        var cursor = write_header_assume_available(layout);
+        if (emit_thread_context) {
+            cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+        }
+        cursor.write_assume_available(end_bytes);
+        cursor.commit();
+
+        return;
+    }
+
+    const first_srcloc = core0_zones[0];
+    var begin_one = q.packet(.ZoneBegin16, .{ .time = 0, .srcloc = @intFromPtr(first_srcloc) });
+    starter_literal_size += @sizeOf(@TypeOf(begin_one));
+
+    if (num_zones == 1) {
+        const layout = wire_layout(starter_literal_size);
+        var cursor = write_header_assume_available(layout);
+        if (emit_thread_context) {
+            cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+        }
+        cursor.write_assume_available(end_bytes);
+        cursor.write_assume_available(std.mem.asBytes(&begin_one));
+        cursor.commit();
+
+        return;
+    }
+
+    starter_literal_size += @sizeOf(@TypeOf(begin_one));
+
+    if (num_zones == 2) {
+        const layout = wire_layout(starter_literal_size);
+        var cursor = write_header_assume_available(layout);
+        if (emit_thread_context) {
+            cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+        }
+        cursor.write_assume_available(end_bytes);
+        cursor.write_assume_available(std.mem.asBytes(&begin_one));
+        begin_one.data.srcloc = @intFromPtr(core0_zones[1]);
+        cursor.write_assume_available(std.mem.asBytes(&begin_one));
+        cursor.commit();
+
+        return;
+    }
+
+    // Remove 4 zeros from the starter literal, this will be part of the first copy
+    starter_literal_size -= 4;
+
+    // The last srcloc will be emitted in a literal tail
+    const tail_size = 9; // 0x80 header, 4 srcloc, 4 zero
+
+    const item_block_size = 1 + 4 + 2; // token 0x43, src_loc 4, 0x000b
+    // -2 for the original begin, -1 for the tail
+    const last_repeat_zone: u32 = @min(num_zones-1, core0_max_zones);
+    const repeat_payload_size = (last_repeat_zone - 2) * item_block_size;
+
+    // If we go past the end of the recorded zone stack, emit a repeated "unknown" begin.
+    var error_copy_bytes: usize = 0;
+    var error_repeat_size: usize = 0;
+    if (num_zones > core0_max_zones + 1) { // +1 because of the tail
+        // 7 bytes to align to the next srcloc, plus a full copy for every repeat
+        // -2: 1 for the original literal and 1 for the trailer
+        error_copy_bytes = 7 + (num_zones - core0_max_zones - 2) * @sizeOf(q.Packet(q.ZoneBegin16));
+        error_repeat_size = item_block_size + match_copy_len_bytes(error_copy_bytes);
+    }
+
+    const total_lz4_size: u32 = header_size(starter_literal_size) + starter_literal_size + 2 + repeat_payload_size + error_repeat_size + tail_size;
+
+    var cursor = send.cursor();
+    cursor.write_assume_available(std.mem.asBytes(&total_lz4_size));
+
+    const token_high: u8 = @min(15, starter_literal_size);
+    const token_low: u8 = 3; // +4, copy 7 byte payload
+    cursor.write_byte_assume_available(token_high << 4 | token_low);
+    if (starter_literal_size >= 15) {
+        var rem = starter_literal_size - 15;
+        while (true) {
+            cursor.write_byte_assume_available(@min(255, rem));
+            if (rem < 255) break;
+            rem -= 255;
+        }
+    }
+    if (emit_thread_context) {
+        cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+    }
+    cursor.write_assume_available(end_bytes);
+    cursor.write_assume_available(std.mem.asBytes(&begin_one));
+    // We can't match copy less than 4 bytes, so we include some of
+    // the second item here to make a larger copyable region
+    cursor.write_assume_available(&.{ @intFromEnum(q.Type.ZoneBegin16), 0, 0 });
+    cursor.write_assume_available(&std.mem.toBytes(@as(u32, @intFromPtr(core0_zones[1]))));
+    // Match copy start at the beginning of begin_one
+    cursor.write_assume_available(&std.mem.toBytes(@as(u16, @sizeOf(@TypeOf(begin_one)))));
+    // Length was 3 in token, no more length bytes here
+
+    // Now we have a literal for every src loc
+    for (core0_zones[2..last_repeat_zone]) |srcloc| {
+        comptime std.debug.assert(@sizeOf(@TypeOf(srcloc)) == 4); // This whole thing is built for 4-byte pointers.
+        cursor.write_byte_assume_available(0x43); // 4 byte literal, 3+4 byte copy
+        cursor.write_assume_available(std.mem.asBytes(&srcloc)); // literal srcloc
+        cursor.write_assume_available(&std.mem.toBytes(@as(u16, @sizeOf(@TypeOf(begin_one))))); // copy from one item back
+    }
+
+    // Then, if we have so many zones that we start repeating the error src loc,
+    // we output a single big match copy for all of those repeats.
+    if (num_zones > core0_max_zones + 1) { // +1 because of the tail
+        const err_token_high: u8 = 4;
+        const err_token_low: u8 = @min(19, error_copy_bytes) - 4;
+        cursor.write_byte_assume_available(err_token_high << 4 | err_token_low);
+        cursor.write_assume_available(&std.mem.toBytes(overflow_zone));
+        cursor.write_assume_available(&std.mem.toBytes(@as(u16, @sizeOf(@TypeOf(begin_one))))); // copy from one item back
+        if (error_copy_bytes >= 19) {
+            var rem = error_copy_bytes - 19;
+            while (true) {
+                cursor.write_byte_assume_available(@min(255, rem));
+                if (rem < 255) break;
+                rem -= 255;
+            }
+        }
+    }
+
+    // Last literal. In the case of going past core0_max_zones, we could include some of this in
+    // the match copy, but with the 5-byte rule for the last block it would only save 3 bytes,
+    // so it's not worth the extra work that would be needed to calculate the length.
+    const last_zone = if (num_zones <= core0_max_zones) core0_zones[num_zones-1] else overflow_zone;
+    cursor.write_byte_assume_available(0x80);
+    cursor.write_assume_available(&std.mem.toBytes(@as(u64, @intFromPtr(last_zone))));
+    cursor.commit();
+}
+
+pub fn available_space_with_reservation() usize {
+    const raw_available = send.available_space();
+    if (state == .connected) {
+        const reserved_space = compute_bulk_end_max_len(core0_num_zones);
+        std.debug.assert(raw_available >= reserved_space);
+        return raw_available - reserved_space;
+    } else {
+        return raw_available;
+    }
+}
+
+
+var time_high: u32 = 0;
+var time_last: u32 = 0;
+pub fn get_time_core0(cs: microzig.interrupt.CriticalSection) i64 {
+    _ = cs; // Just to make sure the caller has a crit sec
+    //return @bitCast(timer.micros());
+    // For higher precision, we read the 32-bit clock counter.
+    // Note that this timer will wrap about once every 30 seconds,
+    // which should be enough for this code to accurately guess
+    // the high part. But if we have very long running intervals
+    // between calls to get_time, we could use the system timer
+    // to fix up the longer time periods.
+    const time = microzig.chip.peripherals.PPB.DWT_CYCCNT.raw;
+    if (time < time_last) time_high += 1;
+    time_last = time;
+    return @bitCast(@as(u64, time_high) << 32 | time);
+}
+
+pub fn is_connected_core0() bool {
+    return @atomicLoad(bool, &atomic_is_connected, .unordered);
+}
+
+pub fn is_connected_core1() bool {
+    return @atomicLoad(bool, &atomic_is_connected, .acquire);
+}
+
+pub fn get_connection_id_core0() u16 {
+    return @atomicLoad(u16, &atomic_connection_id, .unordered);
+}
+
+pub fn get_connection_id_core1() bool {
+    return @atomicLoad(u16, &atomic_connection_id, .acquire);
+}
+
+// If a RTT transaction on core 0 times out, call this to trigger a disconnect.
+pub fn core0_rtt_timeout(stream_valid: bool) void {
+    log("\nTERRY: CORE0 RTT TIMEOUT!\n\n");
+    if (is_connected_core0()) {
+        @atomicStore(bool, &atomic_is_connected,false, .release);
+        clear_queues(); // We've probably been blocking for a while, unblock other threads.
+
+        // Note: Changing the state here might interrupt a pending send.
+        // This is fine, sends are atomic packets and can safely be cancelled.
+        // Still good to keep in mind.
+        if (stream_valid) {
+            send_empty(.Terminate, .timeout);
+        } else {
+            state = .timeout;
+        }
+    }
+}
+
+pub fn wait_for_connection(deadline: u64) !bool {
+    while (true) {
+        if (is_connected_core0()) return true;
+        if (state == .terminal) return false;
+        if (timer.micros() > deadline) return error.Timeout;
+        poll();
+    }
+}
+
+pub fn is_waiting_for_connection() bool {
+    return !is_connected_core0() and state != .terminal;
+}
+
+pub fn is_buffer_full() bool {
+    return state == .buffer_full;
+}
+
+pub fn try_resume_data(time: i64) bool {
+    const resume_safety_margin = 128;
+    const necessary_bytes = compute_bulk_begin_max_len(core0_num_zones) + resume_safety_margin + compute_bulk_end_max_len(core0_num_zones);
+    if (send.available_space() >= necessary_bytes) {
+        core0_emit_bulk_begin(time);
+        state = .connected;
+        return true;
+    }
+    return false;
+}
+
+pub fn data_overflow(time: i64) void {
+    @as(*volatile State, &state).* = .buffer_full;
+    core0_emit_bulk_end(time);
+    state = .buffer_full;
+}
+
+pub fn poll() void {
+    // After handling a packet, if we haven't processed queues this poll, we need to do that.
+    // Otherwise skip the queues and handle another server query.
+    var poll_queues_after_packet = true;
+
+    dispatch: switch (state) {
+        .uninitialized => {
+            microzig.chip.peripherals.PPB.DWT_CTRL.modify(.{ .CYCCNTENA = 1 });
+            startup_time = get_time_core0(undefined);
+            log("TERRY: .uninitialized => .wait_for_server\n");
+            state = .wait_for_server;
+            continue :dispatch state;
+        },
+        .wait_for_server => {
+            // TODO more robust shibboleth handling is necessary for on-demand,
+            // where there might be junk from the previous connection before
+            // the shibboleth, which could offset the rtt stream arbitrarily.
+            // We really want to search the RTT queue for the shibboleth, and
+            // clear it if not found.
+            var shibboleth: [q.HandshakeShibboleth.len]u8 = undefined;
+            if (recv.read_if_available(&shibboleth)) {
+                if (std.mem.eql(u8, &shibboleth, q.HandshakeShibboleth)) {
+                    log("TERRY: .wait_for_server => .handshake\n");
+                    state = .handshake;
+                } else {
+                    log("TERRY: invalid shibboleth! => .terminal\n");
+                    state = .terminal;
+                }
+                continue :dispatch state;
+            }
+        },
+        .handshake => {
+            var protocol_ver: u32 = 0;
+            if (recv.read_if_available(std.mem.asBytes(&protocol_ver))) {
+                if (protocol_ver != q.ProtocolVersion) {
+                    logf("TERRY: invalid protocol version! expect {d}, found {d}\n", .{q.ProtocolVersion, protocol_ver});
+                    state = .bad_protocol_version;
+                } else {
+                    log("TERRY: .handshake => .send_welcome_msg\n");
+                    state = .send_welcome_msg;
+                }
+                continue :dispatch state;
+            }
+        },
+        .send_welcome_msg => {
+            const msg = make_welcome_msg();
+            if (send.write_if_available(std.mem.asBytes(&msg))) {
+                log("TERRY: .send_welcome_msg => .send_on_demand_payload\n");
+                state = .send_on_demand_payload;
+                continue :dispatch state;
+            }
+        },
+        .send_on_demand_payload => {
+            // TODO on-demand
+            log("TERRY: .send_on_demand_payload => .new_connection\n");
+            state = .new_connection;
+            continue :dispatch state;
+        },
+        .new_connection => {
+            if (support_on_demand) {
+                clear_queues();
+            }
+
+            // Make sure we have enough space for some data and a bulk end before starting
+            std.debug.assert(core0_num_zones == 0); // TODO on-demand this might not be true on reconnect, might need special handling
+            if (send.available_space() < 128 + compute_bulk_end_max_len(0)) {
+                return;
+            }
+
+            if (support_on_demand) {
+                @atomicRmw(u16, &atomic_connection_id, .Add, 1, .release);
+            }
+            has_core0_thread_context = false;
+            @atomicStore(bool, &atomic_is_connected, true, .release);
+            interrupt_trace_enabled = true;
+            last_keep_alive_us = timer.micros();
+            log("TERRY: .new_connection => .connected\n");
+            state = .connected;
+            continue :dispatch state;
+        },
+        .connected => {
+            try_send_packet();
+            if (state != .connected) {
+                continue :dispatch state;
+            }
+
+            if (!disconnect_requested) {
+                do_systime();
+                do_syspower();
+                // TODO round-robin to avoid serial queue starvation deadlock?
+                send_core1_queue();
+                send_serial_queue();
+            } else {
+                clear_queues();
+            }
+
+            // TODO keep-alive once every 5 seconds
+
+            poll_queues_after_packet = false;
+
+            var query: q.ServerQueryPacket = undefined;
+            while (pending_packet_type == .no_packet and state == .connected) {
+                // TODO maybe put a deadline here to avoid very long polls handling a chatty server
+
+                if (!recv.read_if_available(std.mem.asBytes(&query))) break;
+
+                logf("TERRY: server query: {s}\n", .{@tagName(query.@"type")});
+
+                switch (query.@"type") {
+                    .ServerQueryString => send_string_ptr(query.ptr, .StringData, .server_query),
+                    .ServerQueryPlotName => send_string_ptr(query.ptr, .PlotName, .server_query),
+                    .ServerQueryFrameName => send_string_ptr(query.ptr, .FrameName, .server_query),
+                    .ServerQueryFiberName => send_string_ptr(query.ptr, .FiberName, .server_query),
+
+                    .ServerQueryThreadString => {
+                        var thread_name: []const u8 = "Unknown Thread";
+                        if (query.ptr == core0_thread_id) {
+                            thread_name = "Core 0 (OS)";
+                        }
+                        send_string(query.ptr, thread_name, .ThreadName, .server_query);
+                    },
+
+                    .ServerQueryExternalName => send_string(query.ptr, "???", .ExternalThreadName, .external_name_pt1), // External name request sends two strings in response
+
+                    .ServerQuerySourceLocation => send_src_loc(query.ptr, .server_query),
+
+                    .ServerQueryCallstackFrame => send_empty(.AckServerQueryNoop, .server_query), // no symbol info
+                    .ServerQuerySymbol => send_empty(.AckServerQueryNoop, .server_query),
+                    .ServerQuerySymbolCode => send_empty(.AckSymbolCodeNotAvailable, .server_query),
+                    .ServerQuerySourceCode => send_empty(.AckSourceCodeNotAvailable, .server_query),
+
+                    // Query data is only used by source code queries, which we don't support.
+                    // So just pretend we're recording it, but we can ignore the data.
+                    .ServerQueryDataTransfer => send_empty(.AckServerQueryNoop, .server_query),
+                    .ServerQueryDataTransferPart => send_empty(.AckServerQueryNoop, .server_query),
+
+                    .ServerQueryParameter => {
+                        const param_idx: u32 = @intCast(query.ptr >> 32);
+                        const param_val: i32 = @bitCast(@as(u32, @truncate(query.ptr)));
+                        if (param_callback_fn) |func| {
+                            func(param_callback_obj, param_idx, param_val);
+                        }
+                        send_empty(.AckServerQueryNoop, .server_query);
+                    },
+
+                    // Disconnect is a handshake.
+                    // Server sends Disconnect, client sends Terminate, server sends Terminate.
+                    // Client can also send Terminate unprompted, which may result in the server
+                    // sending Terminate back.
+                    .ServerQueryDisconnect => {
+                        disconnect_requested = true;
+                        send_empty(.Terminate, .server_query);
+                    },
+                    .ServerQueryTerminate => {
+                        state = .terminating;
+                        continue :dispatch state;
+                    },
+                    _ => {
+                        // TODO any special error handling to do here?
+                        std.debug.assert(false);
+                    },
+                }
+
+                try_send_packet();
+                if (state != .connected) {
+                    continue :dispatch state;
+                }
+            }
+        },
+
+        .buffer_full => {
+            clear_queues();
+            const time = get_time_core0(undefined);
+            if (try_resume_data(time)) {
+                continue :dispatch .connected;
+            }
+        },
+
+        .terminating => {
+            @atomicStore(bool, &atomic_is_connected, false, .release);
+            if (support_on_demand) {
+                // TODO the server might send trailing packets before signing off, we need to
+                // handle clearing these out or we will get an invalid shibboleth and end up
+                // in .unrecoverable_error
+                log("TERRY: .terminating => .wait_for_server\n");
+                state = .wait_for_server;
+            } else {
+                // Terminating is effectively unrecoverable, no more connections can be made
+                // unless on-demand is supported.
+                log("TERRY: .terminating => .terminal\n");
+                state = .terminal;
+            }
+            // Don't continue the state here, let poll() loop.
+        },
+
+        .timeout => {
+            // TODO can we reset an RTT stream safely? Do that to the send stream if possible.
+            if (support_on_demand) {
+                // TODO the server might send trailing packets before signing off, we need to
+                // handle clearing these out or we will get an invalid shibboleth and end up
+                // in .unrecoverable_error
+                log("TERRY: .timeout => .wait_for_server\n");
+                state = .wait_for_server;
+            } else {
+                // Terminating is effectively unrecoverable, no more connections can be made
+                // unless on-demand is supported.
+                log("TERRY: .timeout => .terminal\n");
+                state = .terminal;
+            }
+            // Don't continue the state here, let poll() loop.
+        },
+
+        .bad_protocol_version => {
+            const status = q.HandshakeStatus.HandshakeProtocolMismatch;
+            if (send.write_if_available(std.mem.asBytes(&status))) {
+                log("TERRY: .bad_protocol_version => .wait_for_server\n");
+                state = .wait_for_server;
+                return; // We could continue with this state, but we'll let the OS loop once to avoid the possibility of a long poll.
+            }
+        },
+
+        .unrecoverable_error => {
+            // Be kind, tell the server we are disconnecting
+            if (@atomicLoad(bool, &atomic_is_connected, .unordered)) {
+                send_empty(.Terminate, .terminal);
+                @atomicStore(bool, &atomic_is_connected, false, .release);
+            } else {
+                log("TERRY: .unrecoverable_error => .terminal\n");
+                state = .terminal;
+            }
+            continue :dispatch state;
+        },
+        .terminal => {
+            clear_queues();
+        },
+    }
+}
+
+fn try_send_packet() void {
+    if (pending_packet_type == .no_packet) return;
+
+    const ty = tmp_packet_as(q.Type).*;
+    const packet_size = q.PacketSize[@intFromEnum(ty)];
+    const data_size = packet_size + tmp_packet_data.len;
+    const layout = wire_layout(data_size);
+    const size = layout.total_bytes;
+    // The packet needs to be sent as a single operation
+    // If we can send it without blocking, do so.
+    {
+        // Use a critical section to make sure interrupts don't write zones in
+        // the middle of our string.
+        var cs = microzig.interrupt.enter_critical_section();
+        const available = available_space_with_reservation();
+        if (available >= size) {
+            var cursor = write_header_assume_available(layout);
+            cursor.write_assume_available(tmp_packet[0..packet_size]);
+            cursor.write_assume_available(tmp_packet_data);
+            cursor.commit();
+
+            cs.leave();
+        } else if (size > rtt.tracy_send_size / 3 and available >= layout.header_bytes + packet_size) {
+            // TODO: Large packet sends should probably not block. Instead,
+            // they could disable profiling with a bulk end, then on poll send
+            // any available data before 
+            const z = terry.core0.zone("Terry Send Large Data Packet (Interrupt Profiling Disabled)", @src()); defer z.end();
+
+            // The packet is likely too large to be able to send
+            // without blocking. We're going to do a blocking send.
+            // We can't safely disable interrupts for that long,
+            // so instead we are just going to disable tracing from
+            // interrupts to keep them from messing with the data.
+            const deadline = timer.micros() + server_timeout_us;
+            interrupt_trace_enabled = false;
+            defer interrupt_trace_enabled = true;
+            std.mem.doNotOptimizeAway(&interrupt_trace_enabled);
+            cs.leave();
+
+            var cursor = write_header_assume_available(layout);
+            cursor.write_assume_available(tmp_packet[0..packet_size]);
+            cursor.commit(); // commit immediately, this packet is too large for one transaction
+
+            send.write_blocking_with_deadline(tmp_packet_data, deadline) catch {
+                // We wrote a partial message, but can't write more without halting.
+                // the system. This might mean the server disconnected, or just that
+                // it's running slowly.
+                // In the future we could choose to temporarily disable tracy,
+                // run a poll loop, and then come back to it. This could possibly
+                // leave the zones in an inconsistent but recoverable state.
+                // For now though, we'll just disconnect.
+                log("TERRY: .send_packet => .unrecoverable_error, timeout in large send\n");
+                state = .unrecoverable_error;
+                return;
+            };
+        } else {
+            // Small packet but we can't send it now, try it next poll.
+            // TODO if this happens for too long, risk a blocking send.
+            cs.leave();
+            return;
+        }
+    }
+
+    tmp_packet_data.len = 0;
+    state = switch (pending_packet_type) {
+        .no_packet => unreachable,
+        .server_query => state,
+        .timeout => .timeout,
+        .terminal => .terminal,
+        .external_name_pt1 => {
+            // Packet from pt1 is still valid and has the thread ID in it
+            const thread_id = tmp_packet_as(q.Packet(q.StringTransfer16)).data.ptr;
+            // TODO: This is the process name. Maybe include cart info?
+            send_string(thread_id, "???", .ExternalName, .server_query);
+            return try_send_packet();
+        },
+    };
+
+    pending_packet_type = .no_packet;
+
+    logf("TERRY: .send_packet => .{s}\n", .{@tagName(state)});
+}
+
+fn send_string_ptr(ptr: u64, ty: q.Type, pending_ty: PendingPacket) void {
+    // TODO fault tolerant string len search
+    const str = std.mem.span(@as([*:0]const u8, @ptrFromInt(@as(usize, @intCast(ptr)))));
+    send_string(ptr, str, ty, pending_ty);
+}
+
+fn send_string(id: u64, str: []const u8, ty: q.Type, pending_ty: PendingPacket) void {
+    pending_packet_type = pending_ty;
+    const len_16: u16 = @intCast(@min(str.len, ~@as(u16, 0)));
+    tmp_packet_as(q.Packet(q.StringTransfer16)).* = .{
+        .ty = ty,
+        .data = .{ .ptr = id, .len = len_16 },
+    };
+    tmp_packet_data = str[0..len_16];
+    logf("TERRY: send_string .{s}='{s}' => .{s}\n", .{ @tagName(ty), str, @tagName(pending_packet_type) });
+}
+
+fn send_src_loc(ptr: u64, pending_ty: PendingPacket) void {
+    pending_packet_type = pending_ty;
+    const src_loc: *q.SourceLocationData = @ptrFromInt(@as(usize, @intCast(ptr)));
+    tmp_packet_as(q.Packet(q.SourceLocation)).* = .{
+        .ty = .SourceLocation,
+        .data = .{
+            .name = @intFromPtr(src_loc.name),
+            .file = @intFromPtr(src_loc.file),
+            .function = @intFromPtr(src_loc.function),
+            .line = src_loc.line,
+            .b = @intCast(src_loc.color & 0xFF),
+            .g = @intCast(src_loc.color >> 8 & 0xFF),
+            .r = @intCast(src_loc.color >> 16 & 0xFF),
+        },
+    };
+    tmp_packet_data.len = 0;
+    logf("TERRY: send_src_loc '{s}@{s}:{d}' => .{s}\n", .{ src_loc.function orelse "<null>", src_loc.file orelse "<null>", src_loc.line, @tagName(pending_packet_type) });
+}
+
+fn send_empty(ty: q.Type, pending_ty: PendingPacket) void {
+    pending_packet_type = pending_ty;
+    std.debug.assert(q.PayloadSize[@intFromEnum(ty)] == 0);
+    tmp_packet_as(q.Packet(q.Empty)).* = .{ .ty = ty, .data = .{} };
+    tmp_packet_data.len = 0;
+    logf("TERRY: send_empty .{s} => .{s}\n", .{ @tagName(ty), @tagName(pending_packet_type) });
+}
+
+fn clear_queues() void {
+    // TODO once we have multiple threads, this function should
+    // dequeue and throw away any data from other threads,
+    // to prevent them from blocking on a full queue.
+}
+
+fn send_core1_queue() void {
+    // TODO copy data from the Core 1 queue to the RTT port
+}
+
+fn send_serial_queue() void {
+    // TODO copy data from the serial queue to the RTT port
+}
+
+fn do_systime() void {
+    // TODO maybe emit systime packets?
+}
+
+fn do_syspower() void {
+    // TODO emit power status packets
+}
+
+// TODO get this through a real config somewhere
+const clk_frequency = 125_000_000;
+
+inline fn make_welcome_msg() q.WelcomeMessage {
+    var msg: q.WelcomeMessage = .{
+        //.timerMul = 1000.0, // nanoseconds per tick
+        .timerMul = 1_000_000_000.0 / clk_frequency,
+        .initBegin = 0,
+        .initEnd = startup_time,
+        .resolution = 1, // timer increments by 1
+        .epoch = 0, // no knowledge of time since epoch is available
+        .exectime = 0, // TODO this is the mtime of the executable file. We actually might know this.
+        .pid = 1, // PID 1, the OS
+        .samplingPeriod = os_sampling_period,
+        .flags = .{
+            .CodeTransfer = false,
+            .CombineSamples = false,
+            .IdentifySamples = false,
+            .IgnoreMemFaults = false,
+            .OnDemand = support_on_demand,
+        },
+        .cpuArch = .CpuArchArm32,
+        .cpuManufacturer = std.mem.zeroes([12]u8),
+        .cpuId = 0, // No cpuid on arm
+        .programName = std.mem.zeroes([q.WelcomeMessageProgramNameSize]u8),
+        .hostInfo = std.mem.zeroes([q.WelcomeMessageHostInfoSize]u8),
+    };
+    const prg_name = "sycl-os-kernel.uf2";
+    msg.programName[0..prg_name.len].* = prg_name[0..].*;
+    _ = std.fmt.bufPrint(&msg.hostInfo,
+        \\OS: SYCL
+        \\Compiler: Zig {f}
+        \\User: root
+        \\Arch: ARM
+        \\CPU: Cortex-M33
+        \\Device: SYCL Badge V2 rev{d}
+        \\CPU cores: 2
+        \\RAM: 520 KB
+        \\Client: Terry
+        \\
+    , .{ builtin.zig_version, rev.rev }) catch @panic("Host Info too large!");
+    return msg;
+}

--- a/src/os/system/terry_protocol.zig
+++ b/src/os/system/terry_protocol.zig
@@ -1,0 +1,1159 @@
+/// This file contains the data layouts of the terry protocol for 0.14.0
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+inline fn static_assert(condition: bool, err: []const u8) void {
+    if (!condition) @compileError(err);
+}
+
+comptime {
+    if (builtin.cpu.arch.endian() != .little)
+            @compileError("Tracy only supports little endian CPUs");
+}
+
+/// ------------------------- Messages for Application comms with server ----------------------------------
+
+pub const Type = enum (u8) {
+    ZoneText,
+    ZoneName,
+    Message,
+    MessageColor,
+    MessageCallstack,
+    MessageColorCallstack,
+    MessageAppInfo,
+    ZoneBeginAllocSrcLoc,
+    ZoneBeginAllocSrcLocCallstack,
+    CallstackSerial,
+    Callstack,
+    CallstackAlloc,
+    CallstackSample,
+    CallstackSample32,
+    CallstackSample16,
+    CallstackSampleContextSwitch,
+    CallstackSampleContextSwitch32,
+    CallstackSampleContextSwitch16,
+    FrameImage,
+    ZoneBegin,
+    ZoneBegin32,
+    ZoneBegin16,
+    ZoneBeginCallstack,
+    ZoneBeginCallstack32,
+    ZoneBeginCallstack16,
+    ZoneEnd,
+    ZoneEnd32,
+    ZoneEnd16,
+    LockWait,
+    LockObtain,
+    LockRelease,
+    LockSharedWait,
+    LockSharedObtain,
+    LockSharedRelease,
+    LockName,
+    MemAlloc,
+    MemAllocNamed,
+    MemFree,
+    MemFreeNamed,
+    MemAllocCallstack,
+    MemAllocCallstackNamed,
+    MemFreeCallstack,
+    MemFreeCallstackNamed,
+    MemDiscard,
+    MemDiscardCallstack,
+    GpuZoneBegin,
+    GpuZoneBeginCallstack,
+    GpuZoneBeginAllocSrcLoc,
+    GpuZoneBeginAllocSrcLocCallstack,
+    GpuZoneEnd,
+    GpuZoneBeginSerial,
+    GpuZoneBeginCallstackSerial,
+    GpuZoneBeginAllocSrcLocSerial,
+    GpuZoneBeginAllocSrcLocCallstackSerial,
+    GpuZoneEndSerial,
+    PlotDataInt,
+    PlotDataFloat,
+    PlotDataDouble,
+    ContextSwitch,
+    ThreadWakeup,
+    GpuTime,
+    GpuContextName,
+    GpuAnnotationName,
+    CallstackFrameSize,
+    SymbolInformation,
+    ExternalNameMetadata,
+    SymbolCodeMetadata,
+    SourceCodeMetadata,
+    FiberEnter,
+    FiberLeave,
+    SectionEnter,
+    SectionLeave,
+    SectionSetup,
+    Terminate,
+    KeepAlive,
+    ThreadContext,
+    GpuCalibration,
+    GpuTimeSync,
+    Crash,
+    CrashReport,
+    ZoneValidation,
+    ZoneColor,
+    ZoneValue,
+    FrameMarkMsg,
+    FrameMarkMsgStart,
+    FrameMarkMsgEnd,
+    FrameVsync,
+    SourceLocation,
+    LockAnnounce,
+    LockTerminate,
+    LockMark,
+    MessageLiteral,
+    MessageLiteralColor,
+    MessageLiteralCallstack,
+    MessageLiteralColorCallstack,
+    GpuNewContext,
+    CallstackFrame,
+    SysTimeReport,
+    SysPowerReport,
+    TidToPid,
+    HwSampleCpuCycle,
+    HwSampleInstructionRetired,
+    HwSampleCacheReference,
+    HwSampleCacheMiss,
+    HwSampleBranchRetired,
+    HwSampleBranchMiss,
+    PlotConfig,
+    ParamSetup,
+    AckServerQueryNoop,
+    AckSourceCodeNotAvailable,
+    AckSymbolCodeNotAvailable,
+    CpuTopology,
+    SingleStringData,
+    SecondStringData,
+    SingleStringData8,
+    SecondStringData8,
+    MemNamePayload,
+    ThreadGroupHint,
+    GpuZoneAnnotation,
+    StringData,
+    ThreadName,
+    PlotName,
+    SourceLocationPayload,
+    CallstackPayload,
+    CallstackAllocPayload,
+    FrameName,
+    FrameImageData,
+    ExternalName,
+    ExternalThreadName,
+    SymbolCode,
+    SourceCode,
+    FiberName,
+    _,
+
+    pub const NUM_TYPES = @typeInfo(@This()).@"enum".fields.len;
+};
+
+fn Extend(A: type, B: type) type {
+    return @Type(.{ .@"struct" = .{
+        .backing_integer = null,
+        .decls = &.{},
+        .fields = @typeInfo(A).@"struct".fields ++ @typeInfo(B).@"struct".fields,
+        .is_tuple = false,
+        .layout = .@"extern",
+    } });
+}
+
+pub const Empty = extern struct {};
+
+pub const ThreadContext = extern struct {
+    thread: u32 align(1),
+};
+
+pub const ZoneBeginLean = extern struct {
+    time: i64 align(1),
+};
+
+pub const ZoneBegin = Extend(ZoneBeginLean, extern struct {
+    srcloc: u64 align(1),    // ptr
+});
+
+pub const ZoneBeginThread = Extend(ZoneBegin, extern struct {
+    thread: u32 align(1),
+});
+
+pub const ZoneBegin32 = extern struct {
+    time: u32 align(1),
+    srcloc: u64 align(1),
+};
+
+pub const ZoneBegin16 = extern struct {
+    time: u16 align(1),
+    srcloc: u64 align(1),
+};
+
+pub const ZoneEnd = extern struct {
+    time: i64 align(1),
+};
+
+pub const ZoneEnd32 = extern struct {
+    time: u32 align(1),
+};
+
+pub const ZoneEnd16 = extern struct {
+    time: u16 align(1),
+};
+
+pub const ZoneEndThread = Extend(ZoneEnd, extern struct {
+    thread: u32 align(1),
+});
+
+pub const ZoneValidation = extern struct {
+    id: u32 align(1),
+};
+
+pub const ZoneValidationThread = Extend(ZoneValidation, extern struct {
+    thread: u32 align(1),
+});
+
+pub const ZoneColor = extern struct {
+    b: u8 align(1),
+    g: u8 align(1),
+    r: u8 align(1),
+};
+
+pub const ZoneColorThread = Extend(ZoneColor, extern struct {
+    thread: u32 align(1),
+});
+
+pub const ZoneValue = extern struct {
+    value: u64 align(1),
+};
+
+pub const ZoneValueThread = Extend(ZoneValue, extern struct {
+    thread: u32 align(1),
+});
+
+pub const StringTransfer = extern struct {
+    ptr: u64 align(1),
+};
+
+pub const StringTransfer16 = Extend(StringTransfer, extern struct {
+    len: u16 align(1),
+});
+
+pub const FrameMark = extern struct {
+    time: i64 align(1),
+    name: u64 align(1),      // ptr
+};
+
+pub const FrameVsync = extern struct {
+    time: i64 align(1),
+    id: u32 align(1),
+};
+
+pub const FrameImage = extern struct {
+    frame: u32 align(1),
+    w: u16 align(1),
+    h: u16 align(1),
+    flip: u8 align(1),
+};
+
+pub const FrameImageFat = Extend(FrameImage, extern struct {
+    image: u64 align(1),     // ptr
+});
+
+pub const SourceLocation = extern struct {
+    name: u64 align(1),
+    function: u64 align(1),  // ptr
+    file: u64 align(1),      // ptr
+    line: u32 align(1),
+    b: u8 align(1),
+    g: u8 align(1),
+    r: u8 align(1),
+};
+
+pub const ZoneTextFat = extern struct {
+    text: u64 align(1),      // ptr
+    size: u16 align(1),
+};
+
+pub const ZoneTextFatThread = Extend(ZoneTextFat, extern struct {
+    thread: u32 align(1),
+});
+
+pub const LockType = enum(u8) {
+    Lockable,
+    SharedLockable,
+    _,
+};
+
+pub const LockAnnounce = extern struct {
+    id: u32 align(1),
+    time: i64 align(1),
+    lckloc: u64 align(1),    // ptr
+    type: LockType align(1),
+};
+
+pub const FiberEnter = extern struct {
+    time: i64 align(1),
+    fiber: u64 align(1),     // ptr
+    thread: u32 align(1),
+    groupHint: i32 align(1),
+};
+
+pub const FiberLeave = extern struct {
+    time: i64 align(1),
+    thread: u32 align(1),
+};
+
+pub const SectionEnter = extern struct {
+    time: i64 align(1),
+    id: u32 align(1),
+    category: u16 align(1),
+};
+
+pub const SectionEnterFat = Extend(SectionEnter, extern struct {
+    text: u64 align(1),      // ptr
+    size: u16 align(1),
+});
+
+pub const SectionLeave = extern struct {
+    time: i64 align(1),
+    id: u32 align(1),
+};
+
+pub const SectionSetup = extern struct {
+    category: u16 align(1),
+};
+
+pub const SectionSetupFat = Extend(SectionSetup, extern struct {
+    text: u64 align(1),      // ptr
+    size: u16 align(1),
+});
+
+pub const LockTerminate = extern struct {
+    id: u32 align(1),
+    time: i64 align(1),
+};
+
+pub const LockWait = extern struct {
+    thread: u32 align(1),
+    id: u32 align(1),
+    time: i64 align(1),
+};
+
+pub const LockObtain = extern struct {
+    thread: u32 align(1),
+    id: u32 align(1),
+    time: i64 align(1),
+};
+
+pub const LockRelease = extern struct {
+    id: u32 align(1),
+    time: i64 align(1),
+};
+
+pub const LockReleaseShared = Extend(LockRelease, extern struct {
+    thread: u32 align(1),
+});
+
+pub const LockMark = extern struct {
+    thread: u32 align(1),
+    id: u32 align(1),
+    srcloc: u64 align(1),    // ptr
+};
+
+pub const LockName = extern struct {
+    id: u32 align(1),
+};
+
+pub const LockNameFat = Extend(LockName, extern struct {
+    name: u64 align(1),      // ptr
+    size: u16 align(1),
+});
+
+pub const PlotDataBase = extern struct {
+    name: u64 align(1),      // ptr
+    time: i64 align(1),
+};
+
+pub const PlotDataInt = Extend(PlotDataBase, extern struct {
+    val: i64 align(1),
+});
+
+pub const PlotDataFloat = Extend(PlotDataBase, extern struct {
+    val: f32 align(1),
+});
+
+pub const PlotDataDouble = Extend(PlotDataBase, extern struct {
+    val: f64 align(1),
+});
+
+pub const MessageSourceType = enum(u8) {
+    User,
+    Tracy,
+    _,
+    
+    pub const COUNT = @typeInfo(@This()).@"enum".fields.len;
+};
+
+pub const MessageSeverity = enum(u8) {
+    Trace,   // Broadly track variable states and events in the software program.
+    Debug,   // Describes variable states and details about specific internal events in the software, that are useful for investigations.
+    Info,    // Describes normal events, which inform on the expected progress and state of your software.
+    Warning, // Describes potentially dangerous situations caused by unexpected events and states.
+    Error,   // Describes the occurrence of unexpected behavior. Does not interrupt the execution of the software.
+    Fatal,   // Describes a critical event that will lead to a software failure/crash.
+    _,
+
+    pub const COUNT = @typeInfo(@This()).@"enum".fields.len;
+};
+
+pub fn MakeMessageMetadata(source: MessageSourceType, severity: MessageSeverity) u8 {
+    static_assert( MessageSourceType.COUNT < ( 1 << 4 ), "We use 4 bits for the messages source." );
+    static_assert( MessageSeverity.COUNT < ( 1 << 4 ), "We use 4 bits for the messages severity." );
+    return ( @intFromEnum(severity) << 4 ) | @intFromEnum(source);
+}
+
+pub fn MessageSourceFromMetadata(metadata: u8) MessageSourceType {
+    return @enumFromInt( metadata & 0x0F );
+}
+
+pub fn MessageSeverityFromMetadata(metadata: u8) MessageSeverity {
+    return @enumFromInt( ( metadata & 0xF0 ) >> 4 );
+}
+
+// QueueMessage*Metadata and QueMessageLiteral* are the only structures sent over the wire
+// All other variants are used only internally to dispatch from the thread to the profiler and interpreted by Profiler::Dequeue
+pub const Message = extern struct {
+    time: i64 align(1),
+};
+
+pub const MessageColor = Extend(Message, extern struct {
+    b: u8 align(1),
+    g: u8 align(1),
+    r: u8 align(1),
+});
+
+pub const MessageMetadata = Extend(Message, extern struct {
+    metadata: u8 align(1),
+});
+
+pub const MessageColorMetadata = Extend(MessageColor, extern struct {
+    metadata: u8 align(1),
+});
+
+pub const MessageLiteral = Extend(Message, extern struct {
+    textAndMetadata: TaggedUserlandAddress align(1),      // ptr + log level/channels
+});
+
+pub const MessageLiteralThread = Extend(MessageLiteral, extern struct {
+    thread: u32 align(1),
+});
+
+pub const MessageColorLiteral = Extend(MessageColor, extern struct {
+    textAndMetadata: TaggedUserlandAddress align(1),      // ptr + log level/channels
+});
+
+pub const MessageColorLiteralThread = Extend(MessageColorLiteral, extern struct {
+    thread: u32 align(1),
+});
+
+pub const MessageFat = Extend(Message, extern struct {
+    textAndMetadata: TaggedUserlandAddress align(1),      // ptr + log level/channels
+    size: u16 align(1),
+});
+
+pub const MessageFatThread = Extend(MessageFat, extern struct {
+    thread: u32 align(1),
+});
+
+pub const MessageColorFat = Extend(MessageColor, extern struct {
+    textAndMetadata: TaggedUserlandAddress align(1),      // ptr + log level/channels
+    size: u16 align(1),
+});
+
+pub const MessageColorFatThread = Extend(MessageColorFat, extern struct {
+    thread: u32 align(1),
+});
+
+// Don't change order, only add new entries at the end, this is also used on trace dumps!
+pub const GpuContextType = enum(u8) {
+    Invalid,
+    OpenGl,
+    Vulkan,
+    OpenCL,
+    Direct3D12,
+    Direct3D11,
+    Metal,
+    Custom,
+    CUDA,
+    Rocprof,
+    WebGPU,
+    _,
+};
+
+pub const GpuContextFlags = packed struct (u8) {
+    GpuContextCalibration: bool,
+    _reserved: u7 = 0,
+};
+
+pub const GpuNewContext = extern struct {
+    cpuTime: i64 align(1),
+    gpuTime: i64 align(1),
+    thread: u32 align(1),
+    period: f32 align(1),
+    context: u8 align(1),
+    flags: GpuContextFlags align(1),
+    type: GpuContextType align(1),
+};
+
+pub const GpuZoneBeginLean = extern struct {
+    cpuTime: i64 align(1),
+    thread: u32 align(1),
+    queryId: u16 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuZoneBegin = Extend(GpuZoneBeginLean, extern struct {
+    srcloc: u64 align(1),
+});
+
+pub const GpuZoneEnd = extern struct {
+    cpuTime: i64 align(1),
+    thread: u32 align(1),
+    queryId: u16 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuZoneAnnotation = extern struct {
+    noteId: i64 align(1),
+    value: f64 align(1),
+    thread: u32 align(1),
+    queryId: u16 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuTime = extern struct {
+    gpuTime: i64 align(1),
+    queryId: u16 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuCalibration = extern struct {
+    gpuTime: i64 align(1),
+    cpuTime: i64 align(1),
+    cpuDelta: i64 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuTimeSync = extern struct {
+    gpuTime: i64 align(1),
+    cpuTime: i64 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuContextName = extern struct {
+    context: u8 align(1),
+};
+
+pub const GpuContextNameFat = Extend(GpuContextName, extern struct {
+    ptr: u64 align(1),
+    size: u16 align(1),
+});
+
+pub const GpuAnnotationName = extern struct {
+    noteId: i64 align(1),
+    context: u8 align(1),
+};
+
+pub const GpuAnnotationNameFat = Extend(GpuAnnotationName, extern struct {
+    ptr: u64 align(1),
+    size: u16 align(1),
+});
+
+pub const MemNamePayload = extern struct {
+    name: u64 align(1),
+};
+
+pub const ThreadGroupHint = extern struct {
+    thread: u32 align(1),
+    groupHint: i32 align(1),
+};
+
+pub const MemAlloc = extern struct {
+    time: i64 align(1),
+    thread: u32 align(1),
+    ptr: u64 align(1),
+    size: [6]u8 align(1),
+
+    pub fn setSize(data: *MemAlloc, size: u64) void {
+        std.debug.assert(size & 0xFFFF_0000_0000_0000 == 0);
+        data.size = std.mem.toBytes(size)[0..6].*;
+    }
+};
+
+pub const MemFree = extern struct {
+    time: i64 align(1),
+    thread: u32 align(1),
+    ptr: u64 align(1),
+};
+
+pub const MemDiscard = extern struct {
+    time: i64 align(1),
+    thread: u32 align(1),
+    name: u64 align(1),
+};
+
+pub const CallstackFat = extern struct {
+    ptr: u64 align(1),
+};
+
+pub const CallstackFatThread = Extend(CallstackFat, extern struct {
+    thread: u32 align(1),
+});
+
+pub const CallstackAllocFat = extern struct {
+    ptr: u64 align(1),
+    nativePtr: u64 align(1),
+};
+
+pub const CallstackAllocFatThread = Extend(CallstackAllocFat, extern struct {
+    thread: u32 align(1),
+});
+
+pub const CallstackSample = extern struct {
+    thread: u32 align(1),
+    time: i64 align(1),
+};
+
+pub const CallstackSampleFat = Extend(CallstackSample, extern struct {
+    ptr: u64 align(1),
+});
+
+pub const CallstackSample32 = extern struct {
+    thread: u32 align(1),
+    time: u32 align(1),
+};
+
+pub const CallstackSample16 = extern struct {
+    thread: u32 align(1),
+    time: u16 align(1),
+};
+
+pub const CallstackFrameSize = extern struct {
+    ptr: u64 align(1),
+    size: u8 align(1),
+};
+
+pub const CallstackFrameSizeFat = Extend(CallstackFrameSize, extern struct {
+    data: u64 align(1),
+    imageName: u64 align(1),
+});
+
+pub const CallstackFrame = extern struct {
+    line: u32 align(1),
+    symAddr: u64 align(1),
+    symLen: u32 align(1),
+};
+
+pub const SymbolInformation = extern struct {
+    line: u32 align(1),
+    symAddr: u64 align(1),
+};
+
+pub const SymbolInformationFat = Extend(SymbolInformation, extern struct {
+    fileString: u64 align(1),
+    needFree: u8 align(1),
+});
+
+pub const CrashReport = extern struct {
+    time: i64 align(1),
+    text: u64 align(1),      // ptr
+};
+
+pub const CrashReportThread = extern struct {
+    thread: u32 align(1),
+};
+
+pub const SysTime = extern struct {
+    time: i64 align(1),
+    sysTime: f32 align(1),
+};
+
+pub const SysPower = extern struct {
+    time: i64 align(1),
+    delta: u64 align(1),
+    name: u64 align(1),  // ptr
+};
+
+pub const ContextSwitch = extern struct {
+    time: i64 align(1),
+    oldThread: u32 align(1),
+    newThread: u32 align(1),
+    cpu: u8 align(1),
+    oldThreadWaitReason: u8 align(1),
+    oldThreadState: u8 align(1),
+    previousCState: u8 align(1),
+    newThreadPriority: i8 align(1),
+    oldThreadPriority: i8 align(1),
+};
+
+pub const ThreadWakeup = extern struct {
+    time: i64 align(1),
+    thread: u32 align(1),
+    cpu: u8 align(1),
+    adjustReason: i8 align(1),
+    adjustIncrement: i8 align(1),
+};
+
+pub const TidToPid = extern struct {
+    tid: u64 align(1),
+    pid: u64 align(1),
+};
+
+pub const HwSample = extern struct {
+    ip: u64 align(1),
+    time: i64 align(1),
+};
+
+pub const PlotFormatType = enum(u8) {
+    Number,
+    Memory,
+    Percentage,
+    _,
+};
+
+pub const PlotConfig = extern struct {
+    name: u64 align(1),      // ptr
+    type: u8 align(1),
+    step: u8 align(1),
+    fill: u8 align(1),
+    color: u32 align(1),
+};
+
+pub const ParamSetup = extern struct {
+    idx: u32 align(1),
+    name: u64 align(1),      // ptr
+    type: u8 align(1),
+    val: i32 align(1),
+};
+
+pub const SourceCodeNotAvailable = extern struct {
+    id: u32 align(1),
+};
+
+pub const CpuTopology = extern struct {
+    package: u32 align(1),
+    die: u32 align(1),
+    core: u32 align(1),
+    thread: u32 align(1),
+};
+
+pub const ExternalNameMetadata = extern struct {
+    thread: u64 align(1),
+    name: u64 align(1),
+    threadName: u64 align(1),
+};
+
+pub const SymbolCodeMetadata = extern struct {
+    symbol: u64 align(1),
+    ptr: u64 align(1),
+    size: u32 align(1),
+};
+
+pub const SourceCodeMetadata = extern struct {
+    ptr: u64 align(1),
+    size: u32 align(1),
+    id: u32 align(1),
+};
+
+pub const TaggedUserlandAddress = extern struct {
+    storage: u64 align(1) = 0,
+
+    const ptrShift: u64 = 8;
+    const highBits: u64 = 0xFF00000000000000;
+
+    pub fn init(addr: ?*const anyopaque, tag_val: u8) @This() {
+        const addr_int: u64 = @intFromPtr(addr);
+        std.debug.assert(addr_int & highBits == 0);
+        return .{ .storage = addr_int << ptrShift | tag_val };
+    }
+
+    pub fn address(t: @This()) u64 {
+        return t.storage >> ptrShift;
+    }
+
+    pub fn address_as(t: @This(), comptime PtrT: type) PtrT {
+        return @ptrFromInt(t.address());
+    }
+
+    pub fn tag(t: @This()) u8 {
+        return @intCast(t.storage & 0xFF);
+    }
+};
+
+pub const ZoneBeginData = extern union {
+    zone_64: Packet(ZoneBegin),
+    zone_32: Packet(ZoneBegin32),
+    zone_16: Packet(ZoneBegin16),
+
+    pub fn set(data: *ZoneBeginData, dt: i64, src_loc: *const SourceLocationData) []const u8 {
+        if (dt < 0) {
+            data.* = .{ .zone_64 = .{ .ty = .ZoneBegin, .data = .{ .time = dt, .srcloc = @intFromPtr(src_loc) } } };
+            return std.mem.asBytes(&data.zone_64);
+        } else if (dt < ProtocolOffset16Bit) {
+            data.* = .{ .zone_16 = .{ .ty = .ZoneBegin16, .data = .{ .time = @intCast(dt), .srcloc = @intFromPtr(src_loc) } } };
+            return std.mem.asBytes(&data.zone_16);
+        } else if (dt < ProtocolOffset32Bit) {
+            data.* = .{ .zone_32 = .{ .ty = .ZoneBegin32, .data = .{ .time = @intCast(dt - ProtocolOffset16Bit), .srcloc = @intFromPtr(src_loc) } } };
+            return std.mem.asBytes(&data.zone_32);
+        } else {
+            data.* = .{ .zone_64 = .{ .ty = .ZoneBegin, .data = .{ .time = dt - ProtocolOffset32Bit, .srcloc = @intFromPtr(src_loc) } } };
+            return std.mem.asBytes(&data.zone_64);
+        }
+    }
+};
+
+pub const ZoneEndData = extern union {
+    zone_64: Packet(ZoneEnd),
+    zone_32: Packet(ZoneEnd32),
+    zone_16: Packet(ZoneEnd16),
+
+    pub fn set(data: *ZoneEndData, dt: i64) []const u8 {
+        if (dt < 0) {
+            data.* = .{ .zone_64 = .{ .ty = .ZoneEnd, .data = .{ .time = dt } } };
+            return std.mem.asBytes(&data.zone_64);
+        } else if (dt < ProtocolOffset16Bit) {
+            data.* = .{ .zone_16 = .{ .ty = .ZoneEnd16, .data = .{ .time = @intCast(dt) } } };
+            return std.mem.asBytes(&data.zone_16);
+        } else if (dt < ProtocolOffset32Bit) {
+            data.* = .{ .zone_32 = .{ .ty = .ZoneEnd32, .data = .{ .time = @intCast(dt - ProtocolOffset16Bit) } } };
+            return std.mem.asBytes(&data.zone_32);
+        } else {
+            data.* = .{ .zone_64 = .{ .ty = .ZoneEnd, .data = .{ .time = dt - ProtocolOffset32Bit } } };
+            return std.mem.asBytes(&data.zone_64);
+        }
+    }
+};
+
+pub const PayloadType = [Type.NUM_TYPES]type {
+    Empty,                                  // zone text
+    Empty,                                  // zone name
+    MessageMetadata,     // Message
+    MessageColorMetadata,// MessageColor
+    MessageMetadata,     // MessageCallstack
+    MessageColorMetadata,// MessageColorCallstack
+    Message,         // app info
+    ZoneBeginLean,   // allocated source location
+    ZoneBeginLean,   // allocated source location, callstack
+    Empty,                                  // callstack memory
+    Empty,                                  // callstack
+    Empty,                                  // callstack alloc
+    CallstackSample,
+    CallstackSample32,
+    CallstackSample16,
+    CallstackSample,   // context switch
+    CallstackSample32, // context switch
+    CallstackSample16, // context switch
+    FrameImage,
+    ZoneBegin,
+    ZoneBegin32,
+    ZoneBegin16,
+    ZoneBegin,       // callstack
+    ZoneBegin32,     // callstack
+    ZoneBegin16,     // callstack
+    ZoneEnd,
+    ZoneEnd32,
+    ZoneEnd16,
+    LockWait,
+    LockObtain,
+    LockRelease,
+    LockWait,        // shared
+    LockObtain,      // shared
+    LockReleaseShared,
+    LockName,
+    MemAlloc,
+    MemAlloc,        // named
+    MemFree,
+    MemFree,         // named
+    MemAlloc,        // callstack
+    MemAlloc,        // callstack, named
+    MemFree,         // callstack
+    MemFree,         // callstack, named
+    MemDiscard,
+    MemDiscard,      // callstack
+    GpuZoneBegin,
+    GpuZoneBegin,    // callstack
+    GpuZoneBeginLean,// allocated source location
+    GpuZoneBeginLean,// allocated source location, callstack
+    GpuZoneEnd,
+    GpuZoneBegin,    // serial
+    GpuZoneBegin,    // serial, callstack
+    GpuZoneBeginLean,// serial, allocated source location
+    GpuZoneBeginLean,// serial, allocated source location, callstack
+    GpuZoneEnd,      // serial
+    PlotDataInt,
+    PlotDataFloat,
+    PlotDataDouble,
+    ContextSwitch,
+    ThreadWakeup,
+    GpuTime,
+    GpuContextName,
+    GpuAnnotationName,
+    CallstackFrameSize,
+    SymbolInformation,
+    Empty,                                  // ExternalNameMetadata - not for wire transfer
+    Empty,                                  // SymbolCodeMetadata - not for wire transfer
+    Empty,                                  // SourceCodeMetadata - not for wire transfer
+    FiberEnter,
+    FiberLeave,
+    SectionEnter,
+    SectionLeave,
+    SectionSetup,
+    // above items must be first
+    Empty,                                  // terminate
+    Empty,                                  // keep alive
+    ThreadContext,
+    GpuCalibration,
+    GpuTimeSync,
+    Empty,                                  // crash
+    CrashReport,
+    ZoneValidation,
+    ZoneColor,
+    ZoneValue,
+    FrameMark,       // continuous frames
+    FrameMark,       // start
+    FrameMark,       // end
+    FrameVsync,
+    SourceLocation,
+    LockAnnounce,
+    LockTerminate,
+    LockMark,
+    MessageLiteral,
+    MessageColorLiteral,
+    MessageLiteral,  // callstack
+    MessageColorLiteral, // callstack
+    GpuNewContext,
+    CallstackFrame,
+    SysTime,
+    SysPower,
+    TidToPid,
+    HwSample,        // cpu cycle
+    HwSample,        // instruction retired
+    HwSample,        // cache reference
+    HwSample,        // cache miss
+    HwSample,        // branch retired
+    HwSample,        // branch miss
+    PlotConfig,
+    ParamSetup,
+    Empty,                                  // server query acknowledgement
+    SourceCodeNotAvailable,
+    Empty,                                  // symbol code not available
+    CpuTopology,
+    Empty,                                  // single string data
+    Empty,                                  // second string data
+    Empty,                                  // single string data, 8 bit length
+    Empty,                                  // second string data, 8 bit length
+    MemNamePayload,
+    ThreadGroupHint,
+    GpuZoneAnnotation, // GPU zone annotation
+    // keep all QueueStringTransfer below
+    StringTransfer16,  // string data
+    StringTransfer16,  // thread name
+    StringTransfer16,  // plot name
+    StringTransfer16,  // allocated source location payload
+    StringTransfer,  // callstack payload
+    StringTransfer,  // callstack alloc payload
+    StringTransfer16,  // frame name
+    StringTransfer,  // frame image data
+    StringTransfer16,  // external name
+    StringTransfer16,  // external thread name
+    StringTransfer,  // symbol code
+    StringTransfer,  // source code
+    StringTransfer16,  // fiber name
+};
+
+pub const PayloadSize: [Type.NUM_TYPES]usize = blk: {
+    var sizes: [Type.NUM_TYPES]usize = undefined;
+    for (PayloadType, &sizes) |Ty, *size| {
+        size.* = @sizeOf(Ty);
+    }
+    break :blk sizes;
+};
+
+pub fn Packet(comptime Payload: type) type {
+    return extern struct {
+        ty: Type align(1),
+        data: Payload align(1),
+    };
+}
+
+pub const PacketSize: [Type.NUM_TYPES]usize = blk: {
+    var sizes: [Type.NUM_TYPES]usize = undefined;
+    for (PayloadType, &sizes) |Ty, *size| {
+        size.* = @sizeOf(Packet(Ty));
+    }
+    break :blk sizes;
+};
+
+pub fn packet(comptime ty: Type, data: PayloadType[@intFromEnum(ty)]) Packet(PayloadType[@intFromEnum(ty)]) {
+    return .{ .ty = ty, .data = data };
+}
+
+pub const MaxPacketSize = blk: {
+    var max: comptime_int = 0;
+    for (PacketSize) |sz| {
+        max = @max(max, sz);
+    }
+    static_assert(max == 32, "Max packet size should be 32 per Tracy design");
+    break :blk max;
+};
+
+pub const ProtocolOffset8Bit  = (1 << 8);
+pub const ProtocolOffset16Bit = (1 << 16);
+pub const ProtocolOffset32Bit = (1 << 16) + (1 << 32);
+
+pub const SourceLocationData = extern struct {
+    name: ?[*:0]const u8,
+    function: ?[*:0]const u8,
+    file: ?[*:0]const u8,
+    line: u32,
+    color: u32,
+};
+
+
+/// ------------------------- Messages for Runtime comms with server ----------------------------------
+
+pub fn Lz4CompressBound( size: u32 ) u32 { return size + ( size / 255 ) + 16; }
+
+pub const ProtocolVersion: u32 = 82;
+pub const BroadcastVersion: u16 = 3;
+
+pub const lz4sz_t = u32;
+
+pub const TargetFrameSize = 256 * 1024;
+pub const LZ4Size = Lz4CompressBound( TargetFrameSize );
+comptime {
+    static_assert( LZ4Size <= std.math.maxInt(lz4sz_t), "LZ4Size greater than lz4sz_t" );
+    static_assert( TargetFrameSize * 2 >= 64 * 1024, "Not enough space for LZ4 stream buffer" );
+}
+
+pub const HandshakeShibboleth = "TracyPrf";
+
+pub const HandshakeStatus = enum (u8) {
+    HandshakePending,
+    HandshakeWelcome,
+    HandshakeProtocolMismatch,
+    HandshakeNotAvailable,
+    HandshakeDropped,
+    _,
+};
+
+pub const WelcomeMessageHostInfoSize = 1024;
+pub const WelcomeMessageProgramNameSize = 64;
+
+// Must increase left query space after handling!
+pub const ServerQuery = enum (u8) {
+    ServerQueryTerminate,
+    ServerQueryString,
+    ServerQueryThreadString,
+    ServerQuerySourceLocation,
+    ServerQueryPlotName,
+    ServerQueryFrameName,
+    ServerQueryParameter,
+    ServerQueryFiberName,
+    ServerQueryExternalName,
+    // Items above are high priority. Split order must be preserved. See IsQueryPrio().
+    ServerQueryDisconnect,
+    ServerQueryCallstackFrame,
+    ServerQuerySymbol,
+    ServerQuerySymbolCode,
+    ServerQuerySourceCode,
+    ServerQueryDataTransfer,
+    ServerQueryDataTransferPart,
+    _,
+};
+
+pub const ServerQueryPacket = extern struct {
+    @"type": ServerQuery align(1),
+    ptr: u64 align(1),
+    extra: u32 align(1),
+};
+
+pub const ServerQueryPacketSize = @sizeOf( ServerQueryPacket );
+comptime {
+    static_assert(ServerQueryPacketSize == 13, "align(1) not working properly");
+}
+
+pub const CpuArchitecture = enum (u8) {
+    CpuArchUnknown,
+    CpuArchX86,
+    CpuArchX64,
+    CpuArchArm32,
+    CpuArchArm64,
+    _,
+};
+
+pub const WelcomeFlags = packed struct (u8) {
+    OnDemand        : bool,
+    IgnoreMemFaults : bool,
+    CodeTransfer    : bool,
+    CombineSamples  : bool,
+    IdentifySamples : bool,
+    _pad: u3 = 0,
+};
+
+pub const WelcomeMessage = extern struct {
+    status: HandshakeStatus align(1) = .HandshakeWelcome,
+    timerMul: f64 align(1),
+    initBegin: i64 align(1),
+    initEnd: i64 align(1),
+    resolution: u64 align(1),
+    epoch: u64 align(1),
+    exectime: u64 align(1),
+    pid: u64 align(1),
+    samplingPeriod: i64 align(1),
+    flags: WelcomeFlags align(1),
+    cpuArch: CpuArchitecture align(1),
+    cpuManufacturer: [12]u8 align(1),
+    cpuId: u32 align(1),
+    programName: [WelcomeMessageProgramNameSize]u8 align(1),
+    hostInfo: [WelcomeMessageHostInfoSize]u8 align(1),
+};
+
+pub const OnDemandPayloadMessage = extern struct {
+    frames: u64 align(1),
+    currentTime: u64 align(1),
+};
+
+pub const BroadcastMessage = extern struct {
+    broadcastVersion: u16 align(1),
+    listenPort: u16 align(1),
+    protocolVersion: u32 align(1),
+    pid: u64 align(1),
+    activeTime: i32 align(1),        // in seconds
+    programName: [WelcomeMessageProgramNameSize]u8 align(1),
+};
+
+pub const BroadcastMessage_v2 = extern struct {
+    broadcastVersion: u16 align(1),
+    listenPort: u16 align(1),
+    protocolVersion: u32 align(1),
+    activeTime: i32 align(1),
+    programName: [WelcomeMessageProgramNameSize]u8 align(1),
+};
+
+pub const BroadcastMessage_v1 = extern struct {
+    broadcastVersion: u32 align(1),
+    protocolVersion: u32 align(1),
+    listenPort: u32 align(1),
+    activeTime: u32 align(1),
+    programName: [WelcomeMessageProgramNameSize]u8 align(1),
+};
+
+pub const BroadcastMessage_v0 = extern struct {
+    broadcastVersion: u32 align(1),
+    protocolVersion: u32 align(1),
+    activeTime: u32 align(1),
+    programName: [WelcomeMessageProgramNameSize]u8 align(1),
+};

--- a/tools/rtt.gdb
+++ b/tools/rtt.gdb
@@ -1,0 +1,24 @@
+target extended-remote :3333
+
+file ./zig-out/firmware/sycl-os-kernel.elf
+
+set remote memory-read-packet-size 1024
+set remote memory-write-packet-size 1024
+
+define rtt-init
+    set $rtt_addr = &RttControlBlock
+    eval "monitor rtt setup 0x%x 0x40 \"SEGGER RTT\"", $rtt_addr
+    monitor rtt polling_interval 1
+    monitor rtt start
+    monitor rtt server start 10345 0
+    monitor rtt server start 10344 1
+end
+
+monitor reset halt
+load
+break drivers.rtt.rtt_initialized
+run
+rtt-init
+delete 1
+break interrupt.zig:70
+continue

--- a/tools/rtt_server.zig
+++ b/tools/rtt_server.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+const port: u16 = 10344;
+const address: std.net.Address = std.net.Address.parseIp("127.0.0.1", port)
+    catch @compileError("Couldn't parse server.address");
+
+const connect_sleep_time_millis: u64 = 10 * 1000;
+
+var socket_buffer: [8 * 1024]u8 = undefined;
+var stdout_buffer: [8 * 1024]u8 = undefined;
+
+pub fn main() !void {
+    var stdout = std.fs.File.stdout().writer(&stdout_buffer);
+    std.debug.print("Looking for RTT server at {f}\n", .{address});
+
+    while (true) {
+        const stream = std.net.tcpConnectToAddress(address) catch |err| {
+            std.debug.print("Failed to connect: {}\n", .{err});
+            std.debug.print("Trying again in {d} seconds\n\n", .{connect_sleep_time_millis / 1000});
+            std.Thread.sleep(connect_sleep_time_millis * 1_000_000); // millis to nanos
+            continue;
+        };
+
+        std.debug.print("{s}", .{"Connected to server\n"});
+        var reader_data = stream.reader(&.{});
+
+        stream_data: while (true) {
+            _ = reader_data.interface().stream(&stdout.interface, .unlimited) catch |err| {
+                stdout.interface.flush() catch {};
+                std.debug.print("\n\n---------- Connection Lost: {} ----------\n", .{err});
+                std.debug.print("{s}", .{"Attempting to reconnect.\n"});
+                break :stream_data;
+            };
+            stdout.interface.flush() catch {};
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Terry, an embedded client compatible with the Tracy profiler. Terry uses RTT via OpenOCD to create a socket that the stock Tracy 0.14.0 client can connect to. It also adds a RTT log server which displays any bytes sent to RTT channel 1, which is currently only used for debugging the tracy connection.

How to use it:

-1. Install OpenOCD, Arm GDB, etc
0. Connect the debug probe and turn on the badge
1. Launch GDB with the script in tools/rtt.gdb (e.g. `arm-none-eabi-gdb -x ./tools/rtt.gdb`)
2. (optional) Monitor the logs with `zig run tools/rtt_server.zig`
3. Open `tracy-profiler` from the [Tracy 0.14.0 release](https://github.com/wolfpld/tracy/releases/tag/v0.14.0)
4. Connect Tracy to 127.0.0.1:10345 (or configure the port in tools/rtt.gdb)
<img width="491" height="457" alt="image" src="https://github.com/user-attachments/assets/c1d08f73-164f-4c09-8b27-eb36f89e2cec" />

5. Enjoy detailed profiling data!

Note that bandwidth over RTT is significantly constrained compared to what Tracy would ideally like to use. If you put a zone in every poll(), even the very fast ones, it will overload the connection. When this happens, Terry will create a special zone showing that data was lost, and stop recording data until a big chunk of RTT is available again. Depending on your computer, OpenOCD version, data send rate, and luck, this loss of data will likely take 30-100 mS to resolve.
<img width="1121" height="678" alt="image" src="https://github.com/user-attachments/assets/5e497f6b-5dda-4b95-b7ff-d3ec289fd8c6" />
To avoid this, I recommend only putting tracy zones in functions that you expect to take more than 0.5mS or functions that happen rarely. Take advantage of the `_cond` variants of zones to only record a zone if a runtime condition is true.

Tracy can be connected at any time while the board is running. However, for now, it can only be connected once. If you disconnect it, or something goes wrong, it cannot be reconnected until the board is restarted. See the TODOs labeled on-demand for more details on what would need to be implemented to fix this.

If you would like to profile from startup, you can set `LATE_TRACY_WAIT_TIME_US` in kernel.zig. If this is nonzero, initialization will wait for tracy to connect. A message will be shown on the LCD to indicate that the board is waiting for this. Once Tracy connects or the wait time expires, the board will continue into the main loop.

If you would like to profile initialization and very early startup, set `EARLY_TRACY_WAIT_TIME_US`. This waits after memory is cleared but before most of the board has been initialized. In particular, the screen has not yet been initialized, so the board displays no indication that it's waiting other than not turning on.

For now, Terry only supports profiling on core 0 and cannot do profiling in interrupts. It's designed with core 1 and interrupt support in mind, but they aren't done yet.