### PR TITLE
State Machine Tracking via Terry

### DIFF
--- a/src/os/cart/api.zig
+++ b/src/os/cart/api.zig
@@ -93,9 +93,6 @@ pub const Pixel = extern struct {
     }
 };
 
-/// Button layout must match kernel.zig ButtonPoller.Buttons exactly:
-/// start, select, a, b, click, up, down, left, right (bits 0-8).
-/// Kernel writes u9 to ipc_controls (0x20020004) each frame when cart sends FRAMEBUFFER_READY.
 pub const Controls = packed struct(u16) {
     start: bool,
     select: bool,
@@ -106,7 +103,7 @@ pub const Controls = packed struct(u16) {
     down: bool,
     left: bool,
     right: bool,
-    _: u7,
+    _pad: u7 = 0,
 };
 
 const is_wasm = switch (builtin.target.cpu.arch) {

--- a/src/os/drivers/microzig_rtt.zig
+++ b/src/os/drivers/microzig_rtt.zig
@@ -221,11 +221,11 @@ pub const channel = struct {
                 c.write_pos = write_offset;
             }
 
-            pub fn get_available(c: *Cursor) usize {
+            pub fn get_available(c: *const Cursor) usize {
                 const read_offset = c.chan.load_read_offset();
 
                 if (read_offset <= c.write_pos) {
-                    return c.chan.size - 1 - (c.write_pos - read_offset);
+                    return c.chan.size + read_offset - c.write_pos - 1;
                 } else {
                     return read_offset - c.write_pos - 1;
                 }
@@ -249,7 +249,14 @@ pub const channel = struct {
                 return false;
             }
 
+            pub fn uncommitted_len(c: *const Cursor) usize {
+                const commit_pos = c.chan.write_offset;
+                return if (commit_pos < c.write_pos) c.write_pos - commit_pos
+                    else c.chan.size + c.write_pos - commit_pos;
+            }
+
             pub fn commit(c: *const Cursor) void {
+                std.debug.assert(c.get_available() >= c.uncommitted_len());
                 std.mem.doNotOptimizeAway(c.chan);
                 std.mem.doNotOptimizeAway(c.chan.buffer);
                 memory_barrier();

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -64,6 +64,9 @@ const BTN_DIAG_US: u64 = 2_000_000; // 2 seconds
 var btn_diag_last_us: u64 = 0;
 var btn_diag_cart_was_running: bool = false; // tracks first-run edge
 
+const overlay_refresh_period_us: u64 = 30_000;
+var overlay_refresh_deadline: u64 = 0;
+
 const EARLY_TRACY_WAIT_TIME_US = 0;
 const LATE_TRACY_WAIT_TIME_US = 0; // 60_000_000 * 10; // 10 minutes
 
@@ -238,6 +241,16 @@ pub fn main() !void {
                     console.printf("[BTN] A: no cart to run (cart_count={d})\r\n", .{cart_count});
                 }
             }
+
+            const now = timer.micros();
+            if (now > overlay_refresh_deadline) {
+                overlay_refresh_deadline = now + overlay_refresh_period_us;
+                fps_overlay.tick_os();
+            }
+
+            if (fps_overlay.is_drawing() and !lcd.isBusy()) {
+                fps_overlay.submit_lcd_work();
+            }
         } else {
             // Keep ipc_controls updated every iteration so carts always read fresh
             // button state (fixes start/select recognition in spaceshooter, metalgear-timer).
@@ -293,7 +306,7 @@ pub fn main() !void {
                         (mailbox.MessageType.getPayload(msg) & 0x2) != 0;
 
                     // Flush selected shared-RAM framebuffer.
-                    fps_overlay.tick();
+                    fps_overlay.tick_cart();
                     ready_framebuffer = @volatileCast(@ptrCast(&mailbox.shared_data.framebuffers[fb_index]));
                     if (has_dirty_rect) {
                         const rx: u16 = mailbox.shared_data.dirty_rect_x;
@@ -479,6 +492,8 @@ fn refreshCartDisplay() void {
         const adc_str = std.fmt.bufPrint(&rev_buf, "ADC:{d}", .{rev.raw_reading}) catch "rev error";
         lcd.drawString(@intCast(lcd.width - 8*adc_str.len), lcd.height - 16, adc_str, gray, lcd.BLACK, 1);
     }
+
+    fps_overlay.redraw();
 }
 
 /// Callback to count carts
@@ -520,6 +535,8 @@ fn runSelectedCart() void {
         multicore.resetCore1();
         timer.sleep_ms(100);
     }
+
+    fps_overlay.reset_for_cart();
 
     // Show loading screen while the UF2 is read from storage and flashed.
     lcd.fillScreen(lcd.BLACK);

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -20,49 +20,26 @@ const loader = @import("loader/loader.zig");
 const multicore = @import("system/multicore.zig");
 const terry = @import("system/terry.zig");
 const mailbox = @import("ipc/mailbox.zig");
+const cart_api = @import("cart/api.zig");
+
+const Controls = cart_api.Controls;
 
 // Use panic handler from system
 pub const panic = @import("system/panic.zig").panic;
 
-// Simple button poller (similar to badge-v1)
-const ButtonPoller = struct {
-    /// All physical buttons on the badge.
-    /// Bits 0-8 mirror the cart API Controls layout (start, select, a, b, click, up, down, left, right)
-    /// so they can be forwarded directly to ipc_controls. Order must match src/os/cart/api.zig Controls.
-    pub const Buttons = packed struct(u9) {
-        start: u1, // GPIO 5 (board.button_start)
-        select: u1, // GPIO 38 (board.button_select)
-        a: u1, // GPIO 6 (board.button_a)
-        b: u1, // GPIO 7 (board.button_b)
-        click: u1, // GPIO 36 (board.joystick_click)
-        up: u1, // GPIO 37
-        down: u1, // GPIO 24
-        left: u1, // GPIO 35
-        right: u1, // GPIO 25
+pub fn read_buttons() Controls {
+    return .{
+        .start = gpio.isButtonPressed(board.button_start),
+        .select = gpio.isButtonPressed(board.button_select),
+        .a = gpio.isButtonPressed(board.button_a),
+        .b = gpio.isButtonPressed(board.button_b),
+        .click = gpio.isButtonPressed(board.joystick_click), // joystick press-in button
+        .up = gpio.isButtonPressed(board.joystick_up),
+        .down = gpio.isButtonPressed(board.joystick_down),
+        .left = gpio.isButtonPressed(board.joystick_left),
+        .right = gpio.isButtonPressed(board.joystick_right),
     };
-
-    pub fn init() ButtonPoller {
-        gpio.initButtons();
-        return ButtonPoller{};
-    }
-
-    pub fn read(self: ButtonPoller) Buttons {
-        _ = self;
-        const start_pressed = gpio.isButtonPressed(board.button_start);
-        const select_pressed = gpio.isButtonPressed(board.button_select);
-        return .{
-            .start = if (start_pressed) 1 else 0,
-            .select = if (select_pressed) 1 else 0,
-            .a = if (gpio.isButtonPressed(board.button_a)) 1 else 0,
-            .b = if (gpio.isButtonPressed(board.button_b)) 1 else 0,
-            .click = if (gpio.isButtonPressed(board.joystick_click)) 1 else 0, // joystick press-in button
-            .up = if (gpio.isButtonPressed(board.joystick_up)) 1 else 0,
-            .down = if (gpio.isButtonPressed(board.joystick_down)) 1 else 0,
-            .left = if (gpio.isButtonPressed(board.joystick_left)) 1 else 0,
-            .right = if (gpio.isButtonPressed(board.joystick_right)) 1 else 0,
-        };
-    }
-};
+}
 
 // Y position for cart list display
 var cart_y_pos: u16 = 2;
@@ -78,7 +55,7 @@ var last_cart_check: u64 = 0;
 
 // Stop combo: require both START+SELECT held for 500ms before triggering
 const STOP_COMBO_HOLD_US: u64 = 500_000;
-var stop_combo_held_since: u64 = 0; // 0 = not currently held
+var stop_combo_deadline: u64 = 0; // 0 = not currently held
 
 // Button diagnostic logging: print raw button state every BTN_DIAG_US microseconds
 // while a cart is running.  Uses timer.micros() so it fires at a wall-clock rate
@@ -91,15 +68,7 @@ const EARLY_TRACY_WAIT_TIME_US = 0;
 const LATE_TRACY_WAIT_TIME_US = 0; // 60_000_000 * 10; // 10 minutes
 
 // Button state tracking
-var joystick_up_was_pressed: bool = false;
-var joystick_down_was_pressed: bool = false;
-var joystick_left_was_pressed: bool = false;
-var joystick_right_was_pressed: bool = false;
-var joystick_click_was_pressed: bool = false;
-var button_a_was_pressed: bool = false;
-var button_b_was_pressed: bool = false;
-var button_select_was_pressed: bool = false;
-var button_start_was_pressed: bool = false;
+var last_buttons: Controls = @bitCast(@as(u16, 0));
 
 // Cursor tracking for cart selection
 var cursor_index: usize = 0; // Which cart is currently selected
@@ -146,18 +115,7 @@ pub fn main() !void {
 
     ready_fb_state.register("kernel.ready_fb_state", .not_ready, @src());
 
-    // Initialize button poller
-    const button_poller = ButtonPoller.init();
-    const initial = button_poller.read();
-    joystick_up_was_pressed = (initial.up == 1);
-    joystick_down_was_pressed = (initial.down == 1);
-    joystick_left_was_pressed = (initial.left == 1);
-    joystick_right_was_pressed = (initial.right == 1);
-    joystick_click_was_pressed = (initial.click == 1);
-    button_a_was_pressed = (initial.a == 1);
-    button_b_was_pressed = (initial.b == 1);
-    button_select_was_pressed = (initial.select == 1);
-    button_start_was_pressed = (initial.start == 1); // start button stops cart and sends back to main menu
+    last_buttons = read_buttons();
 
     // Initial cart display
     refreshCartDisplay();
@@ -188,127 +146,102 @@ pub fn main() !void {
         var cart_running = (cart_state == .running) or (cart_state == .ready);
 
         // Poll buttons
-        const buttons = button_poller.read();
+        const buttons = read_buttons();
+        const changed: Controls = @bitCast(@as(u16, @bitCast(buttons)) ^ @as(u16, @bitCast(last_buttons)));
+        const pressed: Controls = @bitCast(@as(u16, @bitCast(buttons)) & @as(u16, @bitCast(changed)));
+        const released: Controls = @bitCast(~@as(u16, @bitCast(buttons)) & @as(u16, @bitCast(changed)));
+        _ = released; // not currently used
+        defer last_buttons = buttons;
 
         // Start + Select combo stops running cart (prevents accidental exit in carts
         // that use the Start button for their own purposes).
         // Require both held for 250ms to avoid accidental trigger when pressing START alone.
-        const stop_combo = (buttons.start == 1 and buttons.select == 1);
-        if (stop_combo) {
-            if (stop_combo_held_since == 0) {
-                stop_combo_held_since = timer.micros();
+        const stop_combo = (buttons.start and buttons.select);
+        if (cart_running and stop_combo) {
+            if (stop_combo_deadline == 0) {
+                stop_combo_deadline = timer.micros() + STOP_COMBO_HOLD_US;
             }
-            const held_us = timer.micros() -% stop_combo_held_since;
-            if (held_us >= STOP_COMBO_HOLD_US and !button_start_was_pressed) {
-                button_start_was_pressed = true;
+            if (timer.micros() > stop_combo_deadline) {
                 console.printf("[BTN] START+SELECT (STOP) pressed (cart_running={})\r\n", .{cart_running});
-                if (cart_running) {
-                    console.println("[STOP] 1: halting Core 1");
-                    multicore.haltCore1();
-                    console.println("[STOP] 2: stopDMA");
-                    lcd.stopDMA();
-                    console.println("[STOP] 3a: resetCartBuzzer");
-                    audio.reset();
-                    console.println("[STOP] 3b: resetCartPWM");
-                    gpio.resetCartPWM();
-                    console.println("[STOP] 3c: resetCartPIO");
-                    gpio.resetCartPIO();
-                    console.println("[STOP] 3d: resetCartNeopixels");
-                    gpio.resetCartNeopixels();
-                    console.println("[STOP] 3e: resetCartLED");
-                    gpio.resetCartLED();
-                    console.println("[STOP] 3f: initButtons");
-                    gpio.initButtons();
-                    console.println("[STOP] 4: abortCartChannels");
-                    dma.abortCartChannels();
-                    console.println("[STOP] 5: loader.stop");
-                    loader.stop();
-                    console.println("[STOP] 6: resetCore1");
-                    multicore.resetCore1();
-                    // Mark cart as stopped and restore state before reinit
-                    cart_running = false;
-                    display_active = true;
-                    btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
-                    ready_fb_state.set_state(.not_ready, @src());
-                    button_a_was_pressed = (buttons.a == 1);
-                    joystick_up_was_pressed = (buttons.up == 1);
-                    joystick_down_was_pressed = (buttons.down == 1);
-                    button_start_was_pressed = (buttons.start == 1 and buttons.select == 1);
-                    console.println("[STOP] 7: reinitDisplay");
-                    lcd.reinitDisplay();
-                    console.println("[STOP] 8: refreshCartDisplay");
-                    refreshCartDisplay();
-                    last_cart_hash = computeCartHash();
-                    console.println("[STOP] 9: done");
-                }
+                console.println("[STOP] 1: halting Core 1");
+                multicore.haltCore1();
+                console.println("[STOP] 2: stopDMA");
+                lcd.stopDMA();
+                console.println("[STOP] 3a: resetCartBuzzer");
+                audio.reset();
+                console.println("[STOP] 3b: resetCartPWM");
+                gpio.resetCartPWM();
+                console.println("[STOP] 3c: resetCartPIO");
+                gpio.resetCartPIO();
+                console.println("[STOP] 3d: resetCartNeopixels");
+                gpio.resetCartNeopixels();
+                console.println("[STOP] 3e: resetCartLED");
+                gpio.resetCartLED();
+                console.println("[STOP] 3f: initButtons");
+                gpio.initButtons();
+                console.println("[STOP] 4: abortCartChannels");
+                dma.abortCartChannels();
+                console.println("[STOP] 5: loader.stop");
+                loader.stop();
+                console.println("[STOP] 6: resetCore1");
+                multicore.resetCore1();
+                // Mark cart as stopped and restore state before reinit
+                cart_running = false;
+                display_active = true;
+                btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
+                ready_fb_state.set_state(.not_ready, @src());
+                console.println("[STOP] 7: reinitDisplay");
+                lcd.reinitDisplay();
+                console.println("[STOP] 8: refreshCartDisplay");
+                refreshCartDisplay();
+                last_cart_hash = computeCartHash();
+                console.println("[STOP] 9: done");
             }
-        } else if (buttons.start == 0 and buttons.select == 0) {
-            // Only reset combo state when BOTH buttons are released.
-            // Resetting when either is still held would allow a quick
-            // tap of the other button to bypass the 250ms hold requirement.
-            stop_combo_held_since = 0;
-            button_start_was_pressed = false;
+        } else {
+            stop_combo_deadline = 0;
         }
 
         // Joystick click toggles FPS overlay at any time (cart running or not)
-        if (buttons.click == 1 and !joystick_click_was_pressed) {
-            joystick_click_was_pressed = true;
+        if (pressed.click) {
             const new_state = !fps_overlay.isEnabled();
             fps_overlay.setEnabled(new_state);
             console.printf("[BTN] CLICK: FPS overlay {s}\r\n", .{if (new_state) "on" else "off"});
-        } else if (buttons.click == 0 and joystick_click_was_pressed) {
-            joystick_click_was_pressed = false;
         }
 
         // Only process navigation buttons when cart is NOT running
         if (!cart_running) {
             // Joystick up - move cursor up through cart list
-            if (buttons.up == 1 and !joystick_up_was_pressed) {
-                joystick_up_was_pressed = true;
+            if (pressed.up) {
                 console.printf("[BTN] UP pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
                 if (cart_count > 0) {
                     cursor_index = if (cursor_index == 0) cart_count - 1 else cursor_index - 1;
                     refreshCartDisplay();
                 }
-            } else if (buttons.up == 0 and joystick_up_was_pressed) {
-                joystick_up_was_pressed = false;
             }
 
             // Joystick down - move cursor down through cart list
-            if (buttons.down == 1 and !joystick_down_was_pressed) {
-                joystick_down_was_pressed = true;
+            if (pressed.down) {
                 console.printf("[BTN] DOWN pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
                 if (cart_count > 0) {
                     cursor_index = (cursor_index + 1) % cart_count;
                     refreshCartDisplay();
                 }
-            } else if (buttons.down == 0 and joystick_down_was_pressed) {
-                joystick_down_was_pressed = false;
             }
 
             // Button A - run the selected cart
-            if (buttons.a == 1 and !button_a_was_pressed) {
-                button_a_was_pressed = true;
+            if (pressed.a) {
                 console.printf("[BTN] A pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
                 if (cart_count > 0 and cursor_index < cart_count) {
                     runSelectedCart();
+                    continue;
                 } else {
                     console.printf("[BTN] A: no cart to run (cart_count={d})\r\n", .{cart_count});
                 }
-            } else if (buttons.a == 0 and button_a_was_pressed) {
-                button_a_was_pressed = false;
             }
         } else {
-            // Reset navigation button states when cart is running to avoid stuck states
-            joystick_up_was_pressed = false;
-            joystick_down_was_pressed = false;
-            button_a_was_pressed = false;
-
             // Keep ipc_controls updated every iteration so carts always read fresh
             // button state (fixes start/select recognition in spaceshooter, metalgear-timer).
-            const ipc_controls: *volatile u16 = @ptrFromInt(0x20020004);
-            const live_btn = button_poller.read();
-            ipc_controls.* = @as(u16, @as(u9, @bitCast(live_btn)));
+            mailbox.shared_data.controls = buttons;
 
             // Periodic diagnostic: print raw GPIO reads + processed button state over USB CDC.
             // Fires on first cart-running entry and then every BTN_DIAG_US microseconds.
@@ -320,27 +253,14 @@ pub fn main() !void {
             }
             if (now_us -% btn_diag_last_us >= BTN_DIAG_US) {
                 btn_diag_last_us = now_us;
-                const start_gpio = gpio.read(board.button_start); // 0=pressed(active-low), 1=released
-                const sel_gpio = gpio.read(board.button_select);
-                const a_gpio = gpio.read(board.button_a);
-                const b_gpio = gpio.read(board.button_b);
-                const up_gpio = gpio.read(board.joystick_up);
-                const dn_gpio = gpio.read(board.joystick_down);
-                const raw_u9: u9 = @bitCast(live_btn);
-                console.printf("[BTN-DIAG] raw_ipc=0x{x:0>3} | gpio(0=pressed): START={d} SEL={d} A={d} B={d} UP={d} DN={d} | processed: start={} sel={} a={} b={} up={} dn={}\r\n", .{
-                    raw_u9,
-                    start_gpio,
-                    sel_gpio,
-                    a_gpio,
-                    b_gpio,
-                    up_gpio,
-                    dn_gpio,
-                    live_btn.start,
-                    live_btn.select,
-                    live_btn.a,
-                    live_btn.b,
-                    live_btn.up,
-                    live_btn.down,
+                console.printf("[BTN-DIAG] raw_ipc=0x{x:0>3} | gpio(0=pressed): START={} SEL={} A={} B={} UP={} DN={} \r\n", .{
+                    @as(u16, @bitCast(buttons)),
+                    buttons.start,
+                    buttons.select,
+                    buttons.a,
+                    buttons.b,
+                    buttons.up,
+                    buttons.down,
                 });
             }
 
@@ -364,10 +284,6 @@ pub fn main() !void {
                 } else if (msg == mailbox.MessageType.FRAMEBUFFER_READY or
                     mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
                 {
-                    // Write button state into the IPC block for the cart to read.
-                    const btn = button_poller.read();
-                    ipc_controls.* = @as(u16, @as(u9, @bitCast(btn))); // u9 zero-extends to u16
-
                     const fb_index: usize = if (mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
                         @intCast(mailbox.MessageType.getPayload(msg) & 0x1)
                     else
@@ -452,11 +368,6 @@ pub fn main() !void {
             display_active = true;
             // Re-sync all button states so any buttons still held when the cart
             // exited are consumed and won't immediately re-trigger menu actions.
-            const cur = button_poller.read();
-            button_a_was_pressed = (cur.a == 1);
-            joystick_up_was_pressed = (cur.up == 1);
-            joystick_down_was_pressed = (cur.down == 1);
-            button_start_was_pressed = (cur.start == 1 and cur.select == 1);
             lcd.reinitDisplay();
             refreshCartDisplay();
             last_cart_hash = computeCartHash(); // Update hash to prevent duplicate refresh
@@ -649,10 +560,7 @@ fn runSelectedCart() void {
     // Write current button state before cart's first frame.
     // Carts read at start of update(); this ensures frame 0 sees real buttons
     // rather than all-zero (which broke metalgear-timer and spaceshooter).
-    const ipc_controls: *volatile u16 = @ptrFromInt(0x20020004);
-    var poller = ButtonPoller.init();
-    const btn = poller.read();
-    ipc_controls.* = @as(u16, @as(u9, @bitCast(btn)));
+    mailbox.shared_data.controls = read_buttons();
 
     // Execute the cart
     console.println("[BTN] calling executeCart...");

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -123,13 +123,14 @@ pub const microzig_options: microzig.Options = .{
     .interrupts = @import("interrupts.zig").interrupts,
 };
 
-var ready_fb_state: enum {
+var ready_fb_state: terry.core0.TrackedStateMachine(enum {
     not_ready,
     ready_rect,
     ready_whole,
     transferring,
     draw_debug,
-} = .not_ready;
+}) = undefined;
+
 var ready_framebuffer: []const u16 = undefined;
 var ready_fb_dirty_rect: [4]u16 = undefined;
 
@@ -142,6 +143,8 @@ pub fn main() !void {
         .early_wait_for_tracy_time = EARLY_TRACY_WAIT_TIME_US,
         .late_wait_for_tracy_time = LATE_TRACY_WAIT_TIME_US,
     });
+
+    ready_fb_state.register("kernel.ready_fb_state", .not_ready, @src());
 
     // Initialize button poller
     const button_poller = ButtonPoller.init();
@@ -162,6 +165,8 @@ pub fn main() !void {
 
     // Auto-start cart if only one is present in storage
     // _ = loader.autoStartSingleCart();
+
+    const z = terry.core0.zone("Kernel Main Loop", @src()); defer z.end();
 
     // Main loop
     while (true) {
@@ -224,6 +229,7 @@ pub fn main() !void {
                     cart_running = false;
                     display_active = true;
                     btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
+                    ready_fb_state.set_state(.not_ready, @src());
                     button_a_was_pressed = (buttons.a == 1);
                     joystick_up_was_pressed = (buttons.up == 1);
                     joystick_down_was_pressed = (buttons.down == 1);
@@ -373,7 +379,6 @@ pub fn main() !void {
                     // Flush selected shared-RAM framebuffer.
                     fps_overlay.tick();
                     ready_framebuffer = @volatileCast(@ptrCast(&mailbox.shared_data.framebuffers[fb_index]));
-                    ready_fb_state = .ready_whole;
                     if (has_dirty_rect) {
                         const rx: u16 = mailbox.shared_data.dirty_rect_x;
                         const ry: u16 = mailbox.shared_data.dirty_rect_y;
@@ -383,13 +388,16 @@ pub fn main() !void {
                         // Fallback to full-frame if rect metadata is invalid.
                         if (!(rw == 0 or rh == 0 or rx >= 160 or ry >= 128)) {
                             ready_fb_dirty_rect = .{ rx, ry, rw, rh };
-                            ready_fb_state = .ready_rect;
+                            ready_fb_state.set_state(.ready_rect, @src());
+                        } else {
+                            ready_fb_state.set_state(.ready_whole, @src());
                         }
                     } else if (!is_v2) {
                         // Legacy carts always imply full-frame updates.
+                        ready_fb_state.set_state(.ready_whole, @src());
                     } else {
                         // No visual change this frame: skip LCD transfer.
-                        ready_fb_state = .transferring;
+                        ready_fb_state.set_state(.transferring, @src());
                     }
                 }
                 // Other messages (e.g. CART_FINISHED) handled by loader state machine.
@@ -397,22 +405,22 @@ pub fn main() !void {
 
             // Dispatch async LCD work
             if (!lcd.isBusy()) {
-                find_lcd_work: switch (ready_fb_state) {
+                find_lcd_work: switch (ready_fb_state.state) {
                     .not_ready => {
                     },
                     .ready_rect => {
                         const rect = ready_fb_dirty_rect;
                         lcd.writeCartBufferRect(ready_framebuffer, rect[0], rect[1], rect[2], rect[3]);
-                        ready_fb_state = .transferring;
+                        ready_fb_state.set_state(.transferring, @src());
                     },
                     .ready_whole => {
                         lcd.writeCartBuffer(ready_framebuffer);
-                        ready_fb_state = .transferring;
+                        ready_fb_state.set_state(.transferring, @src());
                     },
                     .transferring => {
                         // Transfer finished, the frame buffer is safe for the app to write
                         //mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
-                        ready_fb_state = .draw_debug;
+                        ready_fb_state.set_state(.draw_debug, @src());
                         continue :find_lcd_work .draw_debug;
                     },
                     .draw_debug => {
@@ -420,7 +428,7 @@ pub fn main() !void {
                             fps_overlay.submit_lcd_work();
                         } else {
                             mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
-                            ready_fb_state = .not_ready;
+                            ready_fb_state.set_state(.not_ready, @src());
                         }
                     },
                 }
@@ -436,7 +444,7 @@ pub fn main() !void {
             console.printf("[CART] natural stop: state={}, restoring display\r\n", .{loader.getState()});
             lcd.stopDMA();
             fps_overlay.reset_for_cart();
-            ready_fb_state = .not_ready;
+            ready_fb_state.set_state(.not_ready, @src());
             // Reset buzzer, PWM, PIO, neopixel/LED outputs, and button pins.
             gpio.resetCartHardware();
             // Abort any DMA transfers the cart may have left running.

--- a/src/os/loader/loader.zig
+++ b/src/os/loader/loader.zig
@@ -7,6 +7,7 @@ const uf2 = @import("uf2.zig");
 const rom = @import("../drivers/rom.zig");
 const interrupt = microzig.interrupt;
 const debug_log = @import("../debug_log.zig");
+const terry = @import("../system/terry.zig");
 
 /// Linker symbols for cart_xip region
 extern const __cart_xip_start__: u8;
@@ -46,7 +47,7 @@ pub const LoadError = error{
 };
 
 /// Current cart state
-var cart_state: CartState = .none;
+var cart_state: terry.core0.TrackedStateMachine(CartState) = undefined;
 
 /// Loaded cart entry point (Reset_Handler address from vector table)
 var cart_entry_point: u32 = 0;
@@ -131,9 +132,13 @@ fn findVectorTableAddr(start_addr: u32, end_addr: u32) ?u32 {
     return null;
 }
 
+pub fn init() void {
+    cart_state.register("loader.cart_state", .none, @src());
+}
+
 /// Get current cart state
 pub fn getState() CartState {
-    return cart_state;
+    return cart_state.state;
 }
 
 /// Get loaded cart entry point
@@ -143,24 +148,24 @@ pub fn getEntryPoint() u32 {
 
 /// Check if a cart is ready to execute
 pub fn isReady() bool {
-    return cart_state == .ready;
+    return cart_state.state == .ready;
 }
 
 /// Check if a cart is currently running
 pub fn isRunning() bool {
-    return cart_state == .running;
+    return cart_state.state == .running;
 }
 
 /// Mark cart as running (called when Core 1 starts execution)
 pub fn markRunning() void {
-    if (cart_state == .ready) {
-        cart_state = .running;
+    if (cart_state.state == .ready) {
+        cart_state.set_state(.running, @src());
     }
 }
 
 /// Stop the current cart
 pub fn stop() void {
-    cart_state = .none;
+    cart_state.set_state(.none, @src());
     cart_entry_point = 0;
 }
 
@@ -209,14 +214,14 @@ pub fn eraseCartRegion() LoadError!void {
 /// Returns the entry point address on success
 pub fn loadUF2Cart(name: []const u8) LoadError!u32 {
     // If a cart is already running, stop Core 1 before erasing cart_xip.
-    if (cart_state == .running) {
+    if (cart_state.state == .running) {
         const multicore = @import("../system/multicore.zig");
         multicore.haltCore1();
         multicore.resetCore1();
     }
 
-    cart_state = .loading;
-    errdefer cart_state = .error_state;
+    cart_state.set_state(.loading, @src());
+    errdefer cart_state.set_state(.error_state, @src());
 
     // Find the cart in FAT12 storage
     const cart_info = storage.findCart(name) orelse {
@@ -237,7 +242,7 @@ pub fn loadUF2Cart(name: []const u8) LoadError!u32 {
     @memcpy(&loaded_cart_name, &cart_info.short_name);
     loaded_cart_size = cart_info.size;
     cart_entry_point = entry_point;
-    cart_state = .ready;
+    cart_state.set_state(.ready, @src());
     return entry_point;
 }
 

--- a/src/os/system/console.zig
+++ b/src/os/system/console.zig
@@ -7,6 +7,7 @@ const timer = @import("../drivers/timer.zig");
 const gpio = @import("../drivers/gpio.zig");
 const lcd = @import("../drivers/lcd.zig");
 const rom = @import("../drivers/rom.zig");
+const rtt = @import("../drivers/rtt.zig");
 const mailbox = @import("../ipc/mailbox.zig");
 const shared_mem = @import("../ipc/shared_mem.zig");
 const storage = @import("../loader/storage.zig");
@@ -170,6 +171,10 @@ pub fn printf(comptime fmt: []const u8, args: anytype) void {
 
 /// Print string to console (USB)
 pub fn print(text: []const u8) void {
+    // TODO handle logging from core 1
+    if (microzig.chip.peripherals.SIO.CPUID.raw == 0) {
+        rtt.log_core0(text);
+    }
     _ = usb.send(text);
 }
 

--- a/src/os/system/fps_overlay.zig
+++ b/src/os/system/fps_overlay.zig
@@ -144,6 +144,10 @@ pub fn reset_for_cart() void {
     reset_debug_text();
 }
 
+pub fn redraw() void {
+    curr_debug_text = 0;
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// Enable or disable the FPS overlay.
@@ -172,7 +176,7 @@ fn time_delta(from: u64, to: u64) u32 {
 
 /// Update the FPS measurement.  Call once per rendered frame (before render()).
 /// Returns the current smoothed FPS value.
-pub fn tick() void {
+pub fn tick_cart() void {
     const now = timer.micros();
 
     if (last_frame_us != 0) {
@@ -185,7 +189,19 @@ pub fn tick() void {
 
     last_frame_us = now;
 
-    update_debug_text();
+    reset_debug_text();
+
+    if (!enabled) return;
+
+    add_cart_debug_text();
+}
+
+pub fn tick_os() void {
+    reset_debug_text();
+
+    if (!enabled) return;
+
+    add_os_debug_text();
 }
 
 pub fn submit_audio_mix_time(start: u64, end: u64, max_poll_time: u32) void {
@@ -247,12 +263,8 @@ pub fn submit_lcd_work() void {
 /// Call after the frame has been flushed to the display (after
 /// lcd.writeCartBuffer() or lcd.present()), while the SPI bus is idle,
 /// so the overlay renders on top of the cart frame.
-fn update_debug_text() void {
-    reset_debug_text();
-
-    if (!enabled) return;
-
-    const z = terry.core0.zone("fps_overlay.update_debug_text", @src()); defer z.end();
+fn add_cart_debug_text() void {
+    const z = terry.core0.zone("fps_overlay.add_cart_debug_text", @src()); defer z.end();
 
     // Yellow text on black.
     // Right-justify the FPS value in 3 characters
@@ -262,10 +274,34 @@ fn update_debug_text() void {
     const fps_str = std.fmt.bufPrint(&buf, "{d:>4}", .{fps_display}) catch "???";
     add_debug_text(.{ .text = fps_str, .x = lcd.width, .y = 0, .alignment = .right, .color = lcd.YELLOW });
 
+    add_os_debug_text();
+
+    // Audio time
+    const audio_avg_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{@as(u32, @intFromFloat(audio_percent.average() * 100))}) catch "!!!!";
+    add_debug_text(.{ .text = audio_avg_str, .x = 0, .y = 0, .alignment = .left, .color = lcd.GREEN });
+
+    const audio_time_str = std.fmt.bufPrint(&buf, "{d:>4}", .{audio_mix_times.average()}) catch "!!!!";
+    add_debug_text(.{ .text = audio_time_str, .x = 0, .y = 8, .alignment = .left, .color = lcd.BLUE });
+
+    if (display_max_audio_delay != 0) {
+        const poll_max_max = poll_max_history.max();
+        const audio_delay_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{poll_max_max * 100 / display_max_audio_delay}) catch "!!!%";
+        add_debug_text(.{ .text = audio_delay_str, .x = 4*font_width, .y = 0, .alignment = .left, .color = lcd.RED });
+    }
+
+    if (display_max_audio != 0) {
+        const audio_max_str = std.fmt.bufPrint(&buf, "{d:>4}", .{display_max_audio}) catch "!!!!";
+        add_debug_text(.{ .text = audio_max_str, .x = 4*font_width, .y = font_height, .alignment = .left, .color = lcd.RED });
+    }
+}
+
+fn add_os_debug_text() void {
     if (poll_max > 0) {
         poll_max_history.submit(poll_max);
         poll_max = 0;
     }
+
+    var buf: [4]u8 = undefined;
 
     const poll_max_avg = poll_max_history.average();
     const pps_str = std.fmt.bufPrint(&buf, "{d:>4}", .{poll_max_avg}) catch "????";
@@ -284,23 +320,6 @@ fn update_debug_text() void {
 
         const read_str = std.fmt.bufPrint(&buf, "{d}", .{reading}) catch "!@*?";
         add_debug_text(.{ .text = read_str, .x = lcd.width, .y = lcd.height - font_height, .alignment = .right, .color = lcd.WHITE });
-    }
-
-    // Audio time
-    const audio_avg_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{@as(u32, @intFromFloat(audio_percent.average() * 100))}) catch "!!!!";
-    add_debug_text(.{ .text = audio_avg_str, .x = 0, .y = 0, .alignment = .left, .color = lcd.GREEN });
-
-    const audio_time_str = std.fmt.bufPrint(&buf, "{d:>4}", .{audio_mix_times.average()}) catch "!!!!";
-    add_debug_text(.{ .text = audio_time_str, .x = 0, .y = 8, .alignment = .left, .color = lcd.BLUE });
-
-    if (display_max_audio_delay != 0) {
-        const audio_delay_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{poll_max_max * 100 / display_max_audio_delay}) catch "!!!%";
-        add_debug_text(.{ .text = audio_delay_str, .x = 4*font_width, .y = 0, .alignment = .left, .color = lcd.RED });
-    }
-
-    if (display_max_audio != 0) {
-        const audio_max_str = std.fmt.bufPrint(&buf, "{d:>4}", .{display_max_audio}) catch "!!!!";
-        add_debug_text(.{ .text = audio_max_str, .x = 4*font_width, .y = font_height, .alignment = .left, .color = lcd.RED });
     }
 }
 

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -229,6 +229,8 @@ pub fn init(config: InitConfig) !void {
         }
     }
 
+    loader.init();
+
     _ = boot_start;
     _ = usb_time;
 }

--- a/src/os/system/terry.zig
+++ b/src/os/system/terry.zig
@@ -18,7 +18,7 @@ fn StringWrap(comptime str: [:0]const u8) type {
     };
 }
 
-inline fn external_string(comptime str: [:0]const u8) [*:0]const u8 {
+pub inline fn external_string(comptime str: [:0]const u8) [*:0]const u8 {
     return &StringWrap(str).bytes;
 }
 
@@ -52,8 +52,8 @@ pub const core0 = struct {
         pub const is_connected = client.is_connected_core0;
         pub const get_connection_id = client.get_connection_id_core0;
 
-        pub fn begin(comptime max_segments: usize) Writer(max_segments) {
-            return .init_with_cs();
+        pub fn begin(comptime max_segments: usize, cs: microzig.interrupt.CriticalSection) Writer(max_segments) {
+            return .init_with_cs(cs);
         }
 
         fn Writer(comptime max_segments: usize) type {
@@ -64,17 +64,13 @@ pub const core0 = struct {
                 num_extents: usize = 0,
                 literal_bytes: usize = 0,
                 reserved_space: usize = 0,
-                cs: microzig.interrupt.CriticalSection,
-                thread_ctx_data: q.Packet(q.ThreadContext) = undefined,
-                has_thread_ctx: bool,
+                has_core0_thread_ctx: bool,
 
-                fn init_with_cs() @This() {
-                    const cs = microzig.interrupt.enter_critical_section();
+                fn init_with_cs(cs: microzig.interrupt.CriticalSection) @This() {
                     return .{
-                        .cs = cs,
                         .start_time_tracy = client.get_time_core0(cs),
                         .ref_time = client.core0_thread_ref_time,
-                        .has_thread_ctx = client.has_core0_thread_context,
+                        .has_core0_thread_ctx = client.has_core0_thread_context,
                     };
                 }
 
@@ -85,12 +81,12 @@ pub const core0 = struct {
                     w.literal_bytes += data.len;
                 }
 
-                pub fn thread_ctx(w: *@This()) void {
-                    if (!w.has_thread_ctx) {
-                        w.thread_ctx_data = .{ .ty = .ThreadContext, .data = .{ .thread = client.core0_thread_id } };
-                        w.add_extent(std.mem.asBytes(&w.thread_ctx_data));
+                pub fn thread_ctx(w: *@This(), thread_ctx_data: *q.Packet(q.ThreadContext)) void {
+                    if (!w.has_core0_thread_ctx) {
+                        thread_ctx_data.* = .{ .ty = .ThreadContext, .data = .{ .thread = client.core0_thread_id() } };
+                        w.add_extent(std.mem.asBytes(thread_ctx_data));
                         w.ref_time = 0;
-                        w.has_thread_ctx = true;
+                        w.has_core0_thread_ctx = true;
                     }
                 }
 
@@ -104,7 +100,7 @@ pub const core0 = struct {
                     return delta;
                 }
 
-                pub fn commit(w: *@This()) void {
+                pub fn commit(w: *@This()) bool {
                     const layout = client.wire_layout(w.literal_bytes);
                     if (client.send.available_space() >= layout.total_bytes + w.reserved_space) {
                         var cursor = client.write_header_assume_available(layout);
@@ -113,15 +109,15 @@ pub const core0 = struct {
                         }
                         cursor.commit();
 
-                        client.has_core0_thread_context = w.has_thread_ctx;
+                        client.has_core0_thread_context = w.has_core0_thread_ctx;
                         client.core0_thread_ref_time = w.ref_time;
+
+                        return true;
                     } else {
                         client.data_overflow(w.start_time_tracy);
-                    }
-                }
 
-                pub fn end(w: *@This()) void {
-                    w.cs.leave();
+                        return false;
+                    }
                 }
             };
         }
@@ -172,8 +168,10 @@ pub const core0 = struct {
     }
 
     noinline fn outline_zone_begin_static(src_loc: *const q.SourceLocationData) u16 {
-        var writer = interface.begin(2);
-        defer writer.end();
+        const cs = microzig.interrupt.enter_critical_section();
+        defer cs.leave();
+
+        var writer = interface.begin(2, cs);
 
         const conn_id = interface.get_connection_id();
 
@@ -181,11 +179,12 @@ pub const core0 = struct {
             client.push_zone(src_loc);
             _ = client.try_resume_data(writer.start_time_tracy);
         } else {
-            writer.thread_ctx();
+            var thread_ctx_data: q.Packet(q.ThreadContext) = undefined;
+            writer.thread_ctx(&thread_ctx_data);
             var begin_data: q.ZoneBeginData = undefined;
             writer.add_extent( begin_data.set( writer.thread_time(), src_loc ) );
             writer.reserved_space = client.reserved_space_for_begin_zone();
-            writer.commit();
+            _ = writer.commit();
 
             client.push_zone(src_loc);
         }
@@ -198,6 +197,7 @@ pub const core0 = struct {
 
         // TODO on-demand check connection ID
         if (!interface.is_connected()) {
+            // TODO Needs CS?
             client.pop_zone();
             return;
         }
@@ -206,23 +206,141 @@ pub const core0 = struct {
     }
 
     noinline fn outline_zone_end() void {
-        var writer = interface.begin(2);
-        defer writer.end();
+        const cs = microzig.interrupt.enter_critical_section();
+        defer cs.leave();
+
+        var writer = interface.begin(2, cs);
 
         if (client.is_buffer_full()) {
             client.pop_zone();
             _ = client.try_resume_data(writer.start_time_tracy);
         } else {
-            writer.thread_ctx();
+            var thread_ctx_data: q.Packet(q.ThreadContext) = undefined;
+            writer.thread_ctx(&thread_ctx_data);
             var end_data: q.ZoneEndData = undefined;
             writer.add_extent( end_data.set( writer.thread_time() ) );
             writer.reserved_space = client.reserved_space_for_end_zone();
-            writer.commit();
+            _ = writer.commit();
 
             client.pop_zone();
         }
     }
+
+    /// A StateMachine which is recorded in Tracy and shown as its own thread
+    /// register() must be called first, to initialize the state machine,
+    /// then set_state() can be called to update the state.
+    pub fn TrackedStateMachine(comptime State: type) type {
+        return struct {
+            state: State,
+            track: client.TrackedSMEntry,
+
+            pub inline fn register(self: *@This(), comptime name: [:0]const u8, comptime initial_state: State, comptime src: std.builtin.SourceLocation) void {
+                self.register_color(name, initial_state, src, 0);
+            }
+
+            pub inline fn register_color(self: *@This(), comptime name: [:0]const u8, comptime initial_state: State, comptime src: std.builtin.SourceLocation, comptime color: u32) void {
+                self.* = .{
+                    .state = initial_state,
+                    .track = .{
+                        .name = external_string(name),
+                        .srcloc = external_source_location(@tagName(initial_state), src, color),
+                    },
+                };
+
+                outline_register(&self.track);
+            }
+
+            pub inline fn set_state(self: *@This(), comptime state: State, comptime src: std.builtin.SourceLocation) void {
+                self.set_state_color(state, src, 0);
+            }
+
+            // TODO: Instead of taking @src() here, generate a bunch of static source locations for all the tag names, and pick
+            // one based on a runtime state value passed here.
+            pub inline fn set_state_color(self: *@This(), comptime state: State, comptime src: std.builtin.SourceLocation, comptime color: u32) void {
+                self.state = state;
+                self.track.srcloc = external_source_location(@tagName(state), src, color);
+
+                if (!interface.is_connected()) return;
+
+                outline_update_state(&self.track);
+            }
+
+        };
+    }
+
+    noinline fn outline_register(track: *client.TrackedSMEntry) void {
+        const cs = microzig.interrupt.enter_critical_section();
+        defer cs.leave();
+
+        if (!interface.is_connected() or client.is_buffer_full()) {
+            client.add_pending_state(track);
+            return;
+        }
+
+        var writer = interface.begin(1, cs);
+
+        var packet: q.TrackedSMRegisterPacket = undefined;
+
+        writer.add_extent( packet.set(track.name, writer.start_time_tracy, track.srcloc) );
+        writer.has_core0_thread_ctx = false;
+
+        writer.reserved_space = client.reserved_space_for_non_zone();
+
+        if (writer.commit()) {
+            @branchHint(.likely);
+            client.add_tracked_state(track);
+        } else {
+            client.add_pending_state(track);
+        }
+    }
+
+    noinline fn outline_add_to_dirty_without_cs(track: *client.TrackedSMEntry) void {
+
+        // Need to check is_in_dirty again because it may have been set between
+        // our first check and when we took the critical section.
+        std.mem.doNotOptimizeAway(track);
+        if (!track.is_in_dirty) {
+            add_to_dirty(track);
+        }
+    }
+
+    noinline fn add_to_dirty(track: *client.TrackedSMEntry) void {
+        std.debug.assert(!track.is_in_dirty);
+        track.is_in_dirty = true;
+        track.next_dirty = client.core0_dirty_list;
+        client.core0_dirty_list = track;
+        client.core0_num_dirty += 1;
+    }
+
+    noinline fn outline_update_state(track: *client.TrackedSMEntry) void {
+        const cs = microzig.interrupt.enter_critical_section();
+        defer cs.leave();
+
+        var writer = interface.begin(1, cs);
+
+        if (client.is_buffer_full()) {
+            _ = client.try_resume_data(writer.start_time_tracy);
+        } else {
+            var packet: q.TrackedSMUpdatePacket = undefined;
+            writer.add_extent( packet.set(track.name, writer.start_time_tracy, track.srcloc) );
+            writer.has_core0_thread_ctx = false; // Clear the thread context
+
+            writer.reserved_space = client.reserved_space_for_non_zone();
+
+            _ = writer.commit();
+        }
+    }
 };
+
+const EnumLiteral = @Type(.enum_literal);
+fn field_slice(str: anytype, start: EnumLiteral, end: EnumLiteral) []const u8 {
+    const Struct = @typeInfo(@TypeOf(str)).pointer.child;
+    comptime { std.debug.assert(@typeInfo(Struct).@"struct".layout == .@"extern"); }
+    const start_offset = @offsetOf(Struct, @tagName(start));
+    const end_offset = @offsetOf(Struct, @tagName(end)) + @sizeOf(@TypeOf(@field(str, @tagName(end))));
+    comptime { std.debug.assert(start_offset <= end_offset); }
+    return std.mem.asBytes(str)[start_offset..end_offset];
+}
 
 pub fn register_parameter_callback(
     comptime Ctx: type,

--- a/src/os/system/terry_client.zig
+++ b/src/os/system/terry_client.zig
@@ -68,7 +68,12 @@ var last_keep_alive_us: u64 = 0;
 // give the server/host the benefit of the doubt.
 pub const server_timeout_us = 1_000_000;
 
-pub const core0_thread_id = 1;
+// TIDs in Terry are pointers to the static string that names them.
+// So the core0 id here is the address of the descriptive name to
+// be used in the Tracy view.
+const core0_thread_id_ptr = terry.external_string("Core 0 (OS)");
+pub fn core0_thread_id() u32 { return @intFromPtr(core0_thread_id_ptr); }
+
 pub var core0_thread_ref_time: i64 = 0;
 pub var has_core0_thread_context: bool = false;
 
@@ -151,6 +156,30 @@ const core0_max_zones = 64;
 var core0_zones: [core0_max_zones]*const q.SourceLocationData = undefined;
 pub var core0_num_zones: u32 = 0;
 
+pub const TrackedSMEntry = struct {
+    name: [*:0]const u8,
+    srcloc: *const q.SourceLocationData,
+    next: ?*TrackedSMEntry = null,
+};
+
+var core0_tracked_states: ?*TrackedSMEntry = null;
+var core0_num_tracked_states: u32 = 0;
+
+var core0_pending_states: ?*TrackedSMEntry = null;
+var core0_num_pending_states: u32 = 0;
+
+pub fn add_tracked_state(entry: *TrackedSMEntry) void {
+    entry.next = core0_tracked_states;
+    core0_tracked_states = entry;
+    core0_num_tracked_states += 1;
+}
+
+pub fn add_pending_state(entry: *TrackedSMEntry) void {
+    entry.next = core0_pending_states;
+    core0_pending_states = entry;
+    core0_num_pending_states += 1;
+}
+
 pub fn push_zone(srcloc: *const q.SourceLocationData) void {
     if (core0_num_zones < core0_max_zones) {
         core0_zones[core0_num_zones] = srcloc;
@@ -180,7 +209,11 @@ pub fn pop_zone() void {
 /// For 9-93 zones: 2 byte header + 14 + 3 bytes + 2 byte offset + 1 byte matchlen + 1 byte final header + 11 bytes final literal
 /// 9-93: 34 bytes
 /// From there every extra byte adds 85 more depth, extending the match copy by up to 255 more bytes.
-fn compute_bulk_end_max_len(num_zones: u32) usize {
+fn compute_zone_bulk_end_max_len(num_zones: u32) usize {
+    // Tracy has a hard limit for how much data can be decompressed at once. This limit is like 70k zones, but here's an assert just in case.
+    const max_zones = (q.TargetFrameSize - @sizeOf(q.Packet(q.ThreadContext)) - @sizeOf(q.Packet(q.ZoneEnd)) - @sizeOf(q.Packet(q.ZoneBegin16))) / @sizeOf(q.Packet(q.ZoneEnd16)) + 1;
+    std.debug.assert(num_zones <= max_zones);
+
     var starter_literal_size: usize = 0;
 
     starter_literal_size += @sizeOf(q.Packet(q.ThreadContext));
@@ -211,7 +244,7 @@ fn compute_bulk_end_max_len(num_zones: u32) usize {
     return @sizeOf(u32) + total_lz4_size;
 }
 
-fn core0_emit_bulk_end(time: i64) void {
+fn core0_emit_zone_bulk_end(time: i64) void {
     const warning_zone = terry.external_source_location("Data Lost, Too Many Zones!", @src(), 0xcc1100);
 
     const num_zones = core0_num_zones;
@@ -224,7 +257,7 @@ fn core0_emit_bulk_end(time: i64) void {
     var thread_ctx: q.Packet(q.ThreadContext) = undefined;
     const dt = if (emit_thread_context) blk: {
         starter_literal_size += @sizeOf(@TypeOf(thread_ctx));
-        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id } };
+        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id() } };
         has_core0_thread_context = true;
         break :blk time;
     } else time - core0_thread_ref_time;
@@ -321,14 +354,6 @@ fn core0_emit_bulk_end(time: i64) void {
     cursor.commit();
 }
 
-pub fn reserved_space_for_begin_zone() usize {
-    return compute_bulk_end_max_len(core0_num_zones + 1);
-}
-
-pub fn reserved_space_for_end_zone() usize {
-    return compute_bulk_end_max_len(@max(1, core0_num_zones) - 1);
-}
-
 /// For a bulk start operation, we have this sequence:
 /// [1 byte ThreadContext + 4 byte threadID] ++ [1 byte ZoneEnd64 tag, 8 bytes timestamp] ++ [1 byte ZoneBegin16, 0x00_00, 4 bytes srcloc, 4 bytes zero] ** N
 ///                                        ^5                                           ^5+9=14                                                        ^14+11=25
@@ -345,7 +370,11 @@ pub fn reserved_space_for_end_zone() usize {
 /// which we can then repeat for 11*N-(max+1) bytes before ending with a literal of the MSB of srcloc and 4 bytes of zero
 /// So our whole sequence is:
 /// For (max+2)+, 2 byte header, 25+4 incompressible, 2 offset, [1 header, 4 srcloc, 2 offset] ** (max+1)-2, [1 header, 4 srcloc, 2 offset, ext matchlen], 1 header, 8 tail
-fn compute_bulk_begin_max_len(num_zones: u32) usize {
+fn compute_zone_bulk_begin_max_len(num_zones: u32) usize {
+    // Tracy has a hard limit for how much data can be decompressed at once. This limit is like 23k zones, but here's an assert just in case.
+    const max_zones = (q.TargetFrameSize - @sizeOf(q.Packet(q.ThreadContext)) - @sizeOf(q.Packet(q.ZoneEnd))) / @sizeOf(q.Packet(q.ZoneBegin16));
+    std.debug.assert(num_zones <= max_zones);
+
     var starter_literal_size: usize = 0;
     starter_literal_size += @sizeOf(q.Packet(q.ThreadContext));
     starter_literal_size += @sizeOf(q.ZoneEndData);
@@ -391,7 +420,7 @@ fn compute_bulk_begin_max_len(num_zones: u32) usize {
     return @sizeOf(u32) + total_lz4_size;
 }
 
-fn core0_emit_bulk_begin(time: i64) void {
+fn core0_emit_zone_bulk_begin(time: i64) void {
     const overflow_zone = terry.external_source_location("Zones Too Deep", @src(), 0x4E3729);
 
     var starter_literal_size: usize = 0;
@@ -404,7 +433,7 @@ fn core0_emit_bulk_begin(time: i64) void {
     var thread_ctx: q.Packet(q.ThreadContext) = undefined;
     const dt = if (emit_thread_context) blk: {
         starter_literal_size += @sizeOf(@TypeOf(thread_ctx));
-        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id } };
+        thread_ctx = .{ .ty = .ThreadContext, .data = .{ .thread = core0_thread_id() } };
         has_core0_thread_context = true;
         break :blk time;
     } else time - core0_thread_ref_time;
@@ -546,10 +575,302 @@ fn core0_emit_bulk_begin(time: i64) void {
     cursor.commit();
 }
 
+/// To end the state machines, we have this sequence for each state machine:
+/// [1 byte ThreadContext + 4 byte name ptr], [1 byte ZoneEnd tag, 8 bytes timestamp], [1 byte ZoneBegin16 tag, 2 bytes zero, 4 bytes error zone, 4 bytes zero]
+/// Within each packet, the only values that change are the name ptr. Everything else is long enough to satisfy the standard requirements.
+fn compute_sm_bulk_end_len(num_states: u32) usize {
+    if (num_states == 0) return 0; // no packet
+
+    if (num_states == 1) {
+        // just a literal
+        return wire_layout(@sizeOf(q.TrackedSMUpdatePacket)).total_bytes;
+    }
+
+    // Each repeat copies 21 bytes, which means it needs 1 byte of extended matchlen.
+    // The last repeat copies only 12 bytes, so it needs 0 bytes of extended matchlen.
+    // We consider a repeat to include the matchlen from the previous 
+    const starter_literal_len = @sizeOf(q.TrackedSMUpdatePacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const starter_lz4_len = header_size(starter_literal_len) + starter_literal_len + 2; // 2 byte offset
+    const num_repeats = num_states - 2;
+    const single_repeat_lz4_bytes = 1 + 1 + 4 + 2; // extended matchlen + header + name ptr + offset
+    const repeat_lz4_len = num_repeats * single_repeat_lz4_bytes;
+    const tail_literal_len = 8;
+    const tail_lz4_len = header_size(tail_literal_len) + tail_literal_len;
+    const total_lz4_len: u32 = starter_lz4_len + repeat_lz4_len + tail_lz4_len;
+
+    return 4 + total_lz4_len; // 4 byte size plus big data packet
+}
+
+fn core0_emit_sm_bulk_end(time: i64) void {
+    const warning_zone = terry.external_source_location("Data Lost, Too Many Zones!", @src(), 0xcc1100);
+
+    const num_states = core0_num_tracked_states;
+    if (num_states == 0) return; // no packet
+
+    has_core0_thread_context = false;
+
+    if (num_states == 1) {
+        const track = core0_tracked_states.?;
+        // just a literal
+        var packet: q.TrackedSMUpdatePacket = undefined;
+        const bytes = packet.set(track.name, time, warning_zone);
+        const layout = wire_layout(bytes.len);
+        var cursor = write_header_assume_available(layout);
+        cursor.write_assume_available(bytes);
+        cursor.commit();
+
+        return;
+    }
+
+    // Each repeat copies 21 bytes, which means it needs 1 byte of extended matchlen.
+    // The last repeat copies only 12 bytes, so it needs 0 bytes of extended matchlen.
+    // We consider a repeat to include the matchlen from the previous 
+    const starter_literal_len = @sizeOf(q.TrackedSMUpdatePacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const starter_lz4_len = header_size(starter_literal_len) + starter_literal_len + 2; // 2 byte offset
+    const num_repeats = num_states - 2;
+    const single_repeat_lz4_bytes = 1 + 1 + 4 + 2; // extended matchlen + header + name ptr + offset
+    const repeat_lz4_len = num_repeats * single_repeat_lz4_bytes;
+    const tail_literal_len = 8;
+    const tail_lz4_len = header_size(tail_literal_len) + tail_literal_len;
+    const total_lz4_len: u32 = starter_lz4_len + repeat_lz4_len + tail_lz4_len;
+
+    var track = core0_tracked_states.?;
+    var cursor = send.cursor();
+    cursor.write_assume_available(std.mem.asBytes(&total_lz4_len));
+    
+    var packet: q.TrackedSMUpdatePacket = undefined;
+    comptime { std.debug.assert(starter_literal_len >= 15 and starter_literal_len < (15 + 255)); }
+    comptime { std.debug.assert(@sizeOf(q.TrackedSMUpdatePacket) - 4 >= 15 + 4); }
+
+    // First literal header
+    cursor.write_byte_assume_available(if (num_states == 2) 0xF8 else 0xFF);
+    cursor.write_byte_assume_available(@intCast(starter_literal_len - 15));
+    // First literal data, first item and second up to ctx
+    cursor.write_assume_available( packet.set(track.name, time, warning_zone) );
+    track = track.next.?;
+    packet.ctx.data = .{ .thread = @intFromPtr(track.name) };
+    cursor.write_assume_available( std.mem.asBytes(&packet.ctx) );
+    const offset: u16 = @sizeOf(q.TrackedSMUpdatePacket);
+    cursor.write_assume_available( &std.mem.toBytes(offset) );
+
+    for (2..num_states) |n| {
+        track = track.next.?;
+        cursor.write_byte_assume_available( @intCast(@sizeOf(q.TrackedSMUpdatePacket) - 4 - 19) );
+        cursor.write_byte_assume_available( if (n+1 == num_states) 0xF8 else 0xFF );
+        cursor.write_assume_available( &std.mem.toBytes(@as(u32, @intFromPtr(track.name))) );
+        cursor.write_assume_available( &std.mem.toBytes(offset) );
+    }
+
+    cursor.write_byte_assume_available(0x80);
+    cursor.write_assume_available( &std.mem.toBytes(@as(u64, @intFromPtr(warning_zone))) );
+
+    cursor.commit();
+}
+
+/// [1 byte ThreadContext + 4 byte name ptr], [1 byte ZoneBegin tag, 8 bytes timestamp, 4 bytes zone, 4 bytes zero]
+/// The name ptr and zone are uncompressable.
+fn core0_compute_sm_bulk_declare_len() usize {
+    const num_states = core0_num_pending_states;
+    if (num_states == 0) return 0;
+    if (num_states == 1) return wire_layout(@sizeOf(q.TrackedSMRegisterPacket)).total_bytes;
+    
+    const first_literal_size = @sizeOf(q.TrackedSMRegisterPacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const single_repeat_size = 1 + 4 + 2 + 1 + 4 + 2;
+    const last_literal_size = 8;
+
+    const total_lz4_size = header_size(first_literal_size) + first_literal_size + 2 + (single_repeat_size * (num_states - 2)) + header_size(last_literal_size) + last_literal_size;
+
+    return 4 + total_lz4_size;
+}
+
+fn core0_emit_sm_bulk_declare_and_mark_tracked(time: i64) void {
+    const num_states = core0_num_pending_states;
+    if (num_states == 0) return;
+
+    // We are going to invalidate core0 thread context
+    has_core0_thread_context = false;
+
+    // At the end of this function, `track` will be the last pending state.
+    // at that point, we need to clear the pending states and link them
+    // into the tracked list.
+    var track = core0_pending_states.?;
+    defer {
+        std.debug.assert(track.next == null);
+        track.next = core0_tracked_states;
+        core0_tracked_states = core0_pending_states;
+        core0_pending_states = null;
+
+        core0_num_tracked_states += num_states;
+        core0_num_pending_states = 0;
+    }
+
+    if (num_states == 1) {
+        var packet: q.TrackedSMRegisterPacket = undefined;
+        const bytes = packet.set(track.name, time, track.srcloc);
+        const layout = wire_layout(bytes.len);
+        var cursor = write_header_assume_available(layout);
+        cursor.write_assume_available(bytes);
+        cursor.commit();
+
+        return;
+    }
+
+    const first_literal_size = @sizeOf(q.TrackedSMRegisterPacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const single_repeat_size = 1 + 4 + 2 + 1 + 4 + 2;
+    const last_literal_size = 8;
+
+    const total_lz4_size: u32 = header_size(first_literal_size) + first_literal_size + 2 + (single_repeat_size * (num_states - 2)) + header_size(last_literal_size) + last_literal_size;
+
+    var cursor = send.cursor();
+    cursor.write_assume_available(&std.mem.toBytes(total_lz4_size));
+
+    comptime { std.debug.assert(header_size(first_literal_size) == 2); }
+    cursor.write_byte_assume_available(0xF5);
+    cursor.write_byte_assume_available(@intCast( first_literal_size - 15 ));
+    var packet: q.TrackedSMRegisterPacket = undefined;
+    const bytes = packet.set(track.name, time, track.srcloc);
+    cursor.write_assume_available(bytes);
+
+    track = track.next.?;
+    packet.ctx.data = .{ .thread = @intFromPtr(track.name) };
+    cursor.write_assume_available(std.mem.asBytes(&packet.ctx));
+
+    const offset: u16 = @sizeOf(q.TrackedSMRegisterPacket);
+    cursor.write_assume_available(&std.mem.toBytes(offset));
+
+    for (2..num_states) |_| {
+        cursor.write_byte_assume_available(0x41);
+        cursor.write_assume_available(&std.mem.toBytes(@as(u32, @intFromPtr(track.srcloc))));
+        cursor.write_assume_available(&std.mem.toBytes(offset));
+        track = track.next.?;
+        cursor.write_byte_assume_available(0x45);
+        cursor.write_assume_available(&std.mem.toBytes(@as(u32, @intFromPtr(track.name))));
+        cursor.write_assume_available(&std.mem.toBytes(offset));
+    }
+
+    cursor.write_byte_assume_available(0x80);
+    cursor.write_assume_available(&std.mem.toBytes(@as(u64, @intFromPtr(track.srcloc))));
+    cursor.commit();
+}
+
+/// [1 byte ThreadContext + 4 byte name ptr], [1 byte ZoneEnd tag, 8 bytes timestamp], [1 byte ZoneBegin16 tag, 2 bytes zero, 4 bytes zone, 4 bytes zero]
+/// The name ptr and zone are uncompressable.
+fn core0_compute_sm_bulk_update_len() usize {
+    const num_states = core0_num_pending_states;
+    if (num_states == 0) return 0;
+    if (num_states == 1) return wire_layout(@sizeOf(q.TrackedSMUpdatePacket)).total_bytes;
+
+    const first_literal_size = @sizeOf(q.TrackedSMUpdatePacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const single_repeat_size = 1 + 4 + 2 + 1 + 4 + 2;
+    const last_literal_size = 8;
+
+    const total_lz4_size = header_size(first_literal_size) + first_literal_size + 2 + (single_repeat_size * (num_states - 2)) + header_size(last_literal_size) + last_literal_size;
+
+    return 4 + total_lz4_size;
+
+}
+
+fn core0_emit_sm_bulk_update(time: i64) void {
+    const num_states = core0_num_tracked_states;
+    if (num_states == 0) return;
+
+    // We are going to invalidate core0 thread context
+    has_core0_thread_context = false;
+
+    var track = core0_tracked_states.?;
+    defer { std.debug.assert(track.next == null); }
+
+    if (num_states == 1) {
+        var packet: q.TrackedSMUpdatePacket = undefined;
+        const bytes = packet.set(track.name, time, track.srcloc);
+        const layout = wire_layout(bytes.len);
+        var cursor = write_header_assume_available(layout);
+        cursor.write_assume_available(bytes);
+        cursor.commit();
+
+        return;
+    }
+
+    const first_literal_size = @sizeOf(q.TrackedSMUpdatePacket) + @sizeOf(q.Packet(q.ThreadContext));
+    const single_repeat_size = 1 + 4 + 2 + 1 + 4 + 2;
+    const last_literal_size = 8;
+
+    const total_lz4_size: u32 = header_size(first_literal_size) + first_literal_size + 2 + (single_repeat_size * (num_states - 2)) + header_size(last_literal_size) + last_literal_size;
+
+    var cursor = send.cursor();
+    cursor.write_assume_available(&std.mem.toBytes(total_lz4_size));
+
+    comptime { std.debug.assert(header_size(first_literal_size) == 2); }
+    cursor.write_byte_assume_available(0xF8);
+    cursor.write_byte_assume_available(@intCast( first_literal_size - 15 ));
+    var packet: q.TrackedSMUpdatePacket = undefined;
+    const bytes = packet.set(track.name, time, track.srcloc);
+    cursor.write_assume_available(bytes);
+
+    track = track.next.?;
+    packet.ctx.data = .{ .thread = @intFromPtr(track.name) };
+    cursor.write_assume_available(std.mem.asBytes(&packet.ctx));
+
+    const offset: u16 = @sizeOf(q.TrackedSMUpdatePacket);
+    cursor.write_assume_available(&std.mem.toBytes(offset));
+
+    for (2..num_states) |_| {
+        cursor.write_byte_assume_available(0x41);
+        cursor.write_assume_available(&std.mem.toBytes(@as(u32, @intFromPtr(track.srcloc))));
+        cursor.write_assume_available(&std.mem.toBytes(offset));
+        track = track.next.?;
+        cursor.write_byte_assume_available(0x48);
+        cursor.write_assume_available(&std.mem.toBytes(@as(u32, @intFromPtr(track.name))));
+        cursor.write_assume_available(&std.mem.toBytes(offset));
+    }
+
+    cursor.write_byte_assume_available(0x80);
+    cursor.write_assume_available(&std.mem.toBytes(@as(u64, @intFromPtr(track.srcloc))));
+    cursor.commit();
+}
+
+fn core0_compute_bulk_end_len(num_zones: u32, num_sms: u32) usize {
+    return compute_zone_bulk_end_max_len(num_zones) +
+        compute_sm_bulk_end_len(num_sms);
+}
+
+fn core0_emit_bulk_end(time: i64) void {
+    core0_emit_zone_bulk_end(time);
+    core0_emit_sm_bulk_end(time);
+}
+
+fn core0_compute_bulk_begin_len(num_zones: u32) usize {
+    return compute_zone_bulk_begin_max_len(num_zones) +
+        core0_compute_sm_bulk_update_len() +
+        core0_compute_sm_bulk_declare_len();
+}
+
+fn core0_emit_bulk_begin(time: i64) void {
+    core0_emit_zone_bulk_begin(time);
+    core0_emit_sm_bulk_update(time);
+    core0_emit_sm_bulk_declare_and_mark_tracked(time);
+}
+
+pub inline fn reserved_space_for_begin_zone() usize {
+    return core0_compute_bulk_end_len(core0_num_zones + 1, core0_num_tracked_states);
+}
+
+pub inline fn reserved_space_for_end_zone() usize {
+    return core0_compute_bulk_end_len(@max(1, core0_num_zones) - 1, core0_num_tracked_states);
+}
+
+pub inline fn reserved_space_for_non_zone() usize {
+    return core0_compute_bulk_end_len(core0_num_zones, core0_num_tracked_states);
+}
+
+pub inline fn reserved_space_post_bulk_begin() usize {
+    return core0_compute_bulk_end_len(core0_num_zones, core0_num_pending_states + core0_num_tracked_states);
+}
+
 pub fn available_space_with_reservation() usize {
     const raw_available = send.available_space();
     if (state == .connected) {
-        const reserved_space = compute_bulk_end_max_len(core0_num_zones);
+        const reserved_space = reserved_space_for_non_zone();
         std.debug.assert(raw_available >= reserved_space);
         return raw_available - reserved_space;
     } else {
@@ -557,8 +878,14 @@ pub fn available_space_with_reservation() usize {
     }
 }
 
-
-var time_high: u32 = 0;
+// Set time_high to force absolute times to be 64 bit.
+// This ensures that packet sizes with thread contexts
+// are predictable, which simplifies some of the LZ4
+// packing routines for bulk begin/end.
+// This limit would naturally be hit after about 30
+// seconds, so forcing these to be large doesn't
+// significantly impact our overall bandwidth.
+var time_high: u32 = q.ProtocolOffset32Bit >> 32 + 1;
 var time_last: u32 = 0;
 pub fn get_time_core0(cs: microzig.interrupt.CriticalSection) i64 {
     _ = cs; // Just to make sure the caller has a crit sec
@@ -628,7 +955,7 @@ pub fn is_buffer_full() bool {
 
 pub fn try_resume_data(time: i64) bool {
     const resume_safety_margin = 128;
-    const necessary_bytes = compute_bulk_begin_max_len(core0_num_zones) + resume_safety_margin + compute_bulk_end_max_len(core0_num_zones);
+    const necessary_bytes = core0_compute_bulk_begin_len(core0_num_zones) + resume_safety_margin + reserved_space_post_bulk_begin();
     if (send.available_space() >= necessary_bytes) {
         core0_emit_bulk_begin(time);
         state = .connected;
@@ -708,15 +1035,19 @@ pub fn poll() void {
 
             // Make sure we have enough space for some data and a bulk end before starting
             std.debug.assert(core0_num_zones == 0); // TODO on-demand this might not be true on reconnect, might need special handling
-            if (send.available_space() < 128 + compute_bulk_end_max_len(0)) {
+            if (send.available_space() < 128 + core0_compute_sm_bulk_declare_len() + reserved_space_post_bulk_begin()) {
                 return;
             }
+
+            // Declare any tracked state machines
+            has_core0_thread_context = false;
+            core0_emit_sm_bulk_declare_and_mark_tracked(get_time_core0(undefined));
 
             if (support_on_demand) {
                 @atomicRmw(u16, &atomic_connection_id, .Add, 1, .release);
             }
-            has_core0_thread_context = false;
             @atomicStore(bool, &atomic_is_connected, true, .release);
+
             interrupt_trace_enabled = true;
             last_keep_alive_us = timer.micros();
             log("TERRY: .new_connection => .connected\n");
@@ -757,13 +1088,10 @@ pub fn poll() void {
                     .ServerQueryFrameName => send_string_ptr(query.ptr, .FrameName, .server_query),
                     .ServerQueryFiberName => send_string_ptr(query.ptr, .FiberName, .server_query),
 
-                    .ServerQueryThreadString => {
-                        var thread_name: []const u8 = "Unknown Thread";
-                        if (query.ptr == core0_thread_id) {
-                            thread_name = "Core 0 (OS)";
-                        }
-                        send_string(query.ptr, thread_name, .ThreadName, .server_query);
-                    },
+                    // Normally query.ptr for ServerQueryThreadString would be a TID, but since we don't
+                    // have TIDs, Terry uses pointers to the name string as its the thread identifier.
+                    // Note that this is also used for Tracked State Machine names, which are tracked as if they were threads.
+                    .ServerQueryThreadString => send_string_ptr(query.ptr, .ThreadName, .server_query),
 
                     .ServerQueryExternalName => send_string(query.ptr, "???", .ExternalThreadName, .external_name_pt1), // External name request sends two strings in response
 
@@ -936,6 +1264,19 @@ fn try_send_packet() void {
                 state = .unrecoverable_error;
                 return;
             };
+
+            if (state == .connected) {
+                const space_needed = reserved_space_for_non_zone();
+                while (send.available_space() < space_needed) {
+                    if (timer.micros() > deadline) {
+                        // TODO the output stream is consistent in this state, we might be able to
+                        // recover from this one.
+                        log("TERRY: .send_packet => .unrecoverable_error, timeout in large send\n");
+                        state = .unrecoverable_error;
+                        return;
+                    }
+                }
+            }
         } else {
             // Small packet but we can't send it now, try it next poll.
             // TODO if this happens for too long, risk a blocking send.

--- a/src/os/system/terry_client.zig
+++ b/src/os/system/terry_client.zig
@@ -710,6 +710,10 @@ fn core0_emit_sm_bulk_declare_and_mark_tracked(time: i64) void {
         const layout = wire_layout(bytes.len);
         var cursor = write_header_assume_available(layout);
         cursor.write_assume_available(bytes);
+
+        std.debug.assert(cursor.uncommitted_len() == layout.total_bytes);
+        std.debug.assert(cursor.uncommitted_len() == core0_compute_sm_bulk_declare_len());
+
         cursor.commit();
 
         return;
@@ -750,6 +754,10 @@ fn core0_emit_sm_bulk_declare_and_mark_tracked(time: i64) void {
 
     cursor.write_byte_assume_available(0x80);
     cursor.write_assume_available(&std.mem.toBytes(@as(u64, @intFromPtr(track.srcloc))));
+
+    std.debug.assert(cursor.uncommitted_len() == 4 + total_lz4_size);
+    std.debug.assert(cursor.uncommitted_len() == core0_compute_sm_bulk_declare_len());
+
     cursor.commit();
 }
 
@@ -786,6 +794,9 @@ fn core0_emit_sm_bulk_update(time: i64) void {
         const layout = wire_layout(bytes.len);
         var cursor = write_header_assume_available(layout);
         cursor.write_assume_available(bytes);
+
+        std.debug.assert(cursor.uncommitted_len() == layout.total_bytes);
+        std.debug.assert(cursor.uncommitted_len() == compute_sm_bulk_end_len(num_states));
         cursor.commit();
 
         return;
@@ -826,6 +837,9 @@ fn core0_emit_sm_bulk_update(time: i64) void {
 
     cursor.write_byte_assume_available(0x80);
     cursor.write_assume_available(&std.mem.toBytes(@as(u64, @intFromPtr(track.srcloc))));
+
+    std.debug.assert(cursor.uncommitted_len() == total_lz4_size + 4);
+    std.debug.assert(cursor.uncommitted_len() == compute_sm_bulk_end_len(num_states));
     cursor.commit();
 }
 
@@ -835,8 +849,16 @@ fn core0_compute_bulk_end_len(num_zones: u32, num_sms: u32) usize {
 }
 
 fn core0_emit_bulk_end(time: i64) void {
+    const write_size = core0_compute_bulk_end_len(core0_num_zones, core0_num_tracked_states);
+    std.debug.assert(send.available_space() >= write_size);
+    const start_pos = send.write_offset;
+
     core0_emit_zone_bulk_end(time);
     core0_emit_sm_bulk_end(time);
+
+    const end_pos = send.write_offset;
+    const len = if (start_pos <= end_pos) end_pos - start_pos else send.size + end_pos - start_pos;
+    std.debug.assert(len == write_size);
 }
 
 fn core0_compute_bulk_begin_len(num_zones: u32) usize {
@@ -846,9 +868,17 @@ fn core0_compute_bulk_begin_len(num_zones: u32) usize {
 }
 
 fn core0_emit_bulk_begin(time: i64) void {
+    const write_size = core0_compute_bulk_begin_len(core0_num_zones);
+    std.debug.assert(send.available_space() >= write_size);
+    const start_pos = send.write_offset;
+
     core0_emit_zone_bulk_begin(time);
     core0_emit_sm_bulk_update(time);
     core0_emit_sm_bulk_declare_and_mark_tracked(time);
+
+    const end_pos = send.write_offset;
+    const len = if (start_pos <= end_pos) end_pos - start_pos else send.size + end_pos - start_pos;
+    std.debug.assert(len == write_size);
 }
 
 pub inline fn reserved_space_for_begin_zone() usize {

--- a/src/os/system/terry_protocol.zig
+++ b/src/os/system/terry_protocol.zig
@@ -836,6 +836,37 @@ pub const ZoneEndData = extern union {
     }
 };
 
+pub const TrackedSMRegisterPacket = extern struct {
+    ctx: Packet(ThreadContext),
+    begin: Packet(ZoneBegin),
+
+    pub fn set(self: *@This(), name: [*:0]const u8, abs_time: i64, new_state: *const SourceLocationData) []const u8 {
+        self.* = .{
+            .ctx = .{ .ty = .ThreadContext, .data = .{ .thread = @intFromPtr(name) } },
+            // absolute time because we changed thread contexts
+            .begin = .{ .ty = .ZoneBegin, .data = .{ .time = abs_time - ProtocolOffset32Bit, .srcloc = @intFromPtr(new_state) } },
+        };
+        return std.mem.asBytes(self);
+    }
+};
+
+pub const TrackedSMUpdatePacket = extern struct {
+    ctx: Packet(ThreadContext),
+    end: Packet(ZoneEnd),
+    begin: Packet(ZoneBegin16),
+
+    pub fn set(self: *@This(), name: [*:0]const u8, abs_time: i64, new_state: *const SourceLocationData) []const u8 {
+        self.* = .{
+            .ctx = .{ .ty = .ThreadContext, .data = .{ .thread = @intFromPtr(name) } },
+            // absolute time because we changed thread contexts
+            .end = .{ .ty = .ZoneEnd, .data = .{ .time = abs_time - ProtocolOffset32Bit } },
+            .begin = .{ .ty = .ZoneBegin16, .data = .{ .time = 0, .srcloc = @intFromPtr(new_state) } },
+        };
+        return std.mem.asBytes(self);
+    }
+};
+
+
 pub const PayloadType = [Type.NUM_TYPES]type {
     Empty,                                  // zone text
     Empty,                                  // zone name


### PR DESCRIPTION
This PR adds functionality in Terry to track state machines over time. From the user's perspective, the state is wrapped in an object with a set_state function, which records tracking information and displays the current state in Tracy.
<img width="679" height="340" alt="image" src="https://github.com/user-attachments/assets/dfcf4670-5763-44b9-8a38-b0ba82b123e6" />
<img width="1151" height="421" alt="image" src="https://github.com/user-attachments/assets/b7791991-dec9-448c-94bd-25c207b7319f" />

Under the hood, Terry implements this by creating a fake "thread" for each state machine. When the state changes, it ends a zone on that thread for the old state and opens a zone for the new state. This approach was chosen over using Tracy's Fiber events because equivalent functionality using fibers would use significantly more bandwidth.

Features to add in the future:
- Custom colors or names for zones
- set_state with a non-comptime state
- sub-zones, e.g. a counter for how many tasks are remaining in the current state

There are also a few unrelated but useful commits in here, including:
- Simplifying the button polling logic in kernel.main
- Showing the OS poll rate on the debug overlay when no cart is active
- Sending console.print messages over RTT in addition to the USB