### PR TITLE
Tracy support for carts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -532,6 +532,9 @@ pub fn add_os_cart(b: *Build, dep: *Build.Dependency, options: OsCartOptions) vo
     // directly import font.zig, which Zig prohibits.
     const board_mod = fw.core_mod.import_table.get("board").?;
     cart_api_module.addImport("board", board_mod);
+    cart_api_module.addImport("tracy_protocol", b.createModule(.{
+        .root_source_file = b.path("src/os/system/tracy_protocol.zig"),
+    }));
 
     mb.install_firmware(fw, .{ .format = .elf });
     mb.install_firmware(fw, .{ .format = .{ .uf2 = .{ .family_id = .RP2350_ARM_S } } });

--- a/src/cart/cart_xip.ld
+++ b/src/cart/cart_xip.ld
@@ -30,22 +30,16 @@ MEMORY
     /* Cart RAM region - for variables, stack, heap.
      *
      * IMPORTANT:  The first part of process_ram is reserved by the OS for the
-     * cart IPC block, framebuffer, and IPC buffers. Do NOT touch these ranges:
+     * cart IPC block, framebuffer, and IPC buffers. For specific layout, see
+     * the CartIPCData structure in os/cart/api.zig
      *
-     *   0x20020000 - 0x2002001F  IPC block (controls, sensors, etc.)    32 B
-    *   0x20020020 - 0x2002A01F  Framebuffer 0 (160 * 128 * 2)      40960 B
-    *   0x2002A020 - 0x2003401F  Framebuffer 1 (160 * 128 * 2)      40960 B
-    *   0x20034020 - 0x2003409F  CART_TRACE_BUF (128 bytes)            128 B
-    *   0x200340A0 - 0x200340A7  CART_TONE_FREQ + CART_TONE_DURATION     8 B
-    *   0x200340A8 - 0x200340AF  Reserved IPC padding                    8 B
-    *   0x200340B0 - 0x200340B7  Dirty-rect metadata (x,y,w,h u16)       8 B
-    *   0x200340B8 - 0x200340FF  Reserved IPC padding                   72 B
-    *   0x20034100 - 0x2007FFFF  Cart RAM (variables, heap, stack)   ~303 KB
+     *   0x20020000 - 0x200350FF  IPC Block                            ~86 KB
+     *   0x20035100 - 0x2007FFFF  Cart RAM (variables, heap, stack)   ~307 KB
      *
      * Cart code writes pixels via api.framebuffer (active draw buffer).
-     * Cart globals start at 0x20034100 to avoid aliasing IPC/framebuffers.
+     * Cart globals start at 0x20035100 to avoid aliasing IPC/framebuffers.
      */
-    RAM(rwx) : ORIGIN = 0x20034100, LENGTH = 0x4BF00
+    RAM(rwx) : ORIGIN = 0x20035100, LENGTH = 0x4AF00
 }
 
 SECTIONS

--- a/src/os/cart.zig
+++ b/src/os/cart.zig
@@ -172,6 +172,7 @@ fn executeCart(exec: mailbox.MessageType.CartExecute) void {
     const cart_xip_start = getCartXipStart();
     const cart_xip_end = getCartXipEnd();
     const cart_ram_start = getCartRamStart();
+    const cart_shared_ram_end = cart_ram_start + 4 + @sizeOf(@TypeOf(mailbox.shared_data.*));
     const cart_ram_end = getCartRamEnd();
     if (exec.xip) {
         const vector_table_addr = cart_xip_start + exec.offset;
@@ -187,7 +188,7 @@ fn executeCart(exec: mailbox.MessageType.CartExecute) void {
             mailbox.send(mailbox.MessageType.CART_CRASHED);
             return;
         }
-        if (initial_sp < 0x2002A100 or initial_sp > 0x20080000) {
+        if (initial_sp < cart_shared_ram_end or initial_sp > cart_ram_end) {
             mailbox.send(mailbox.MessageType.CART_CRASHED);
             return;
         }

--- a/src/os/cart/api.zig
+++ b/src/os/cart/api.zig
@@ -273,7 +273,7 @@ fn resetDirtyRect() void {
     dirty_max_y = 0;
 }
 
-pub inline fn markDirtyRect(x: i32, y: i32, w: i32, h: i32) void {
+pub fn markDirtyRect(x: i32, y: i32, w: i32, h: i32) void {
     if (w <= 0 or h <= 0) return;
 
     const x0 = @max(x, 0);
@@ -337,7 +337,7 @@ fn clipPixel(x: i32, y: i32, pixel: Pixel) void {
 }
 
 /// Copies pixels to the framebuffer.
-pub inline fn blit(options: BlitOptions) void {
+pub fn blit(options: BlitOptions) void {
     if (is_wasm) {
         struct {
             extern fn blit(sprite: [*]const DisplayColor, x: i32, y: i32, width: u32, height: u32, src_x: u32, src_y: u32, stride: u32, flags: BlitOptions.Flags) void;
@@ -408,7 +408,7 @@ pub const LineOptions = struct {
 };
 
 /// Draws a line between two points.
-pub inline fn line(options: LineOptions) void {
+pub fn line(options: LineOptions) void {
     if (is_wasm) {
         struct {
             extern fn line(color: DisplayColor, x1: i32, y1: i32, x2: i32, y2: i32) void;
@@ -459,7 +459,7 @@ pub const OvalOptions = struct {
 };
 
 /// Draws an oval (or circle).
-pub inline fn oval(options: OvalOptions) void {
+pub fn oval(options: OvalOptions) void {
     if (is_wasm) {
         struct {
             extern fn oval(stroke_color: DisplayColor.Optional, fill_color: DisplayColor.Optional, x: i32, y: i32, width: u32, height: u32) void;
@@ -578,7 +578,7 @@ pub const RectOptions = struct {
 };
 
 /// Draws a rectangle.
-pub inline fn rect(options: RectOptions) void {
+pub fn rect(options: RectOptions) linksection(".ramfunc") void {
     if (is_wasm) {
         struct {
             extern fn rect(stroke_color: DisplayColor.Optional, fill_color: DisplayColor.Optional, x: i32, y: i32, width: u32, height: u32) void;
@@ -648,7 +648,7 @@ pub const TextOptions = struct {
 };
 
 /// Draws text using the built-in system font.
-pub inline fn text(options: TextOptions) void {
+pub fn text(options: TextOptions) void {
     if (is_wasm) {
         struct {
             extern fn text(text_color: DisplayColor.Optional, background_color: DisplayColor.Optional, str_ptr: [*]const u8, str_len: usize, x: i32, y: i32, scale: u32) void;
@@ -738,7 +738,7 @@ pub const StraightLineOptions = struct {
 };
 
 /// Draws a horizontal line
-pub inline fn hline(options: StraightLineOptions) void {
+pub fn hline(options: StraightLineOptions) void {
     if (is_wasm) {
         struct {
             extern fn hline(color: DisplayColor, x: i32, y: i32, len: u32) void;
@@ -759,7 +759,7 @@ pub inline fn hline(options: StraightLineOptions) void {
 }
 
 /// Draws a vertical line
-pub inline fn vline(options: StraightLineOptions) void {
+pub fn vline(options: StraightLineOptions) void {
     if (is_wasm) {
         struct {
             extern fn vline(color: DisplayColor, x: i32, y: i32, len: u32) void;
@@ -866,7 +866,7 @@ pub const Tone2Options = struct {
 /// Plays a sound tone via the hardware buzzer.
 /// Cancels any other audio that might be playing.
 /// On native: sends CART_TONE IPC to kernel; kernel plays via gpio.buzzer.
-pub inline fn tone2(options: Tone2Options) void {
+pub fn tone2(options: Tone2Options) void {
     if (is_wasm) {
         // TODO: Update wasm to handle new float values
         const adj_duration: u32 = if (options.duration == -1)
@@ -901,7 +901,7 @@ pub inline fn tone2(options: Tone2Options) void {
 /// Adjust the volume of all audio, 0.0 - 1.0. This is a perceptually
 /// linear scale from about -50dB to 0dB adjustment from the maximum
 /// speaker volume.
-pub inline fn setGlobalVolume(volume: f32) void {
+pub fn setGlobalVolume(volume: f32) void {
     if (is_wasm) {
         // TODO wasm volume
     } else {
@@ -1292,7 +1292,7 @@ noinline fn outline_zone_end(time: i64, record_block: bool) linksection(".ramfun
 
 /// Returns a random number from the RP2350 ring oscillator random bit.
 /// Useful for seeding a faster PRNG.
-pub inline fn rand() u32 {
+pub fn rand() u32 {
     if (is_wasm) {
         return struct {
             extern fn rand() u32;
@@ -1312,7 +1312,7 @@ pub inline fn rand() u32 {
 /// Prints a message to the debug console.
 /// On native: copies string to shared buffer and sends CART_TRACE via FIFO;
 /// kernel prints to UART. Used by Blobs and other carts for panic/debug output.
-pub inline fn trace(x: []const u8) void {
+pub fn trace(x: []const u8) void {
     if (is_wasm) {
         struct {
             extern fn trace(str_ptr: [*]const u8, str_len: usize) void;
@@ -1343,7 +1343,7 @@ pub inline fn trace(x: []const u8) void {
 ///
 /// Call this once per frame (typically at the end of `update()`).
 /// On WASM this is a no-op because the simulator owns the display.
-pub inline fn present() void {
+pub fn present() void {
     if (is_wasm) {
         // Simulator flushes automatically — nothing to do.
         return;

--- a/src/os/cart/api.zig
+++ b/src/os/cart/api.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const q = @import("tracy_protocol");
 
 // ┌───────────────────────────────────────────────────────────────────────────┐
 // │                                                                           │
@@ -33,6 +34,86 @@ pub fn microsSinceBoot() u64 {
         const lr = TIMER0_TIMELR.*; // always lr first
         const hr = TIMER0_TIMEHR.*;
         return (@as(u64, hr) << 32) | lr;
+    }
+}
+
+/// A 64 bit offset to align core 1 times with core 0 times.
+/// This is set before cart startup by the OS.
+var cycles_offset: i64 = 0;
+var last_cycles: u32 = 0;
+/// Cycle count for profiling. This must be called at least once
+/// every 30 seconds to maintain accuracy. The OS will call it
+/// before every update() to maintain this, but if update()
+/// ever takes more than 30 seconds there may be mistakes. 
+pub fn cycles() linksection(".ramfunc") i64 {
+    if (is_wasm) {
+        return @bitCast(microsSinceBoot());
+    } else {
+        const DWT_CYCCNT: *volatile u32 = @ptrFromInt(0xe0001004);
+        const cycles_low = DWT_CYCCNT.*;
+        if (cycles_low < last_cycles) {
+            @branchHint(.unlikely);
+            cycles_offset += (1 << 32);
+        }
+        last_cycles = cycles_low;
+        return cycles_offset + cycles_low;
+    }
+}
+
+/// Aligns core 0 and core 1 cycle counts for profiling.
+/// If you have an extremely long update (30+ seconds),
+/// or you put core 1 to sleep, you can call this to
+/// resynchronize and restore correct timing in tracy.
+/// This function must wait until the OS is ready to
+/// synchronize timing, which could take several
+/// milliseconds in the worst case.
+pub fn os_align_cycles() void {
+    if (!is_wasm) {
+        // RP2350 SIO FIFO registers (same address on both cores, core-local view)
+        const SIO_FIFO_ST: *volatile u32 = @ptrFromInt(0xD0000050);
+        const SIO_FIFO_WR: *volatile u32 = @ptrFromInt(0xD0000054);
+        const SIO_FIFO_RD: *volatile u32 = @ptrFromInt(0xD0000058);
+
+        const FIFO_RDY: u32 = 1 << 1; // write-FIFO ready (space available)
+        const FIFO_VLD: u32 = 1 << 0; // read-FIFO valid (data available)
+
+        // Message constants — must match mailbox.MessageType values in the OS.
+        const SYNC_TIME_REQ_CLR: u32 = 0x2a000001;
+        const SYNC_TIME_ACK_CLR: u32 = 0x2a000002;
+        const SYNC_TIME_REQ_TIME: u32 = 0x2a000003;
+
+        // Clear OS FIFO
+        while (SIO_FIFO_ST.* & FIFO_VLD != 0) {
+            _ = SIO_FIFO_RD.*;
+        }
+
+        // Tell OS to clear its fifo
+        while (SIO_FIFO_ST.* & FIFO_RDY == 0) {}
+        SIO_FIFO_WR.* = SYNC_TIME_REQ_CLR;
+
+        // Wait for OS to acknowledge clearing its fifo
+        while (true) {
+            while (SIO_FIFO_ST.* & FIFO_VLD == 0) {}
+            if (SIO_FIFO_RD.* == SYNC_TIME_ACK_CLR) break;
+        }
+
+        // Send time request for immediate processing
+        while (SIO_FIFO_ST.* & FIFO_RDY == 0) {}
+        SIO_FIFO_WR.* = SYNC_TIME_REQ_TIME;
+
+        // Read cycle count at approx same time as other core
+        const DWT_CYCCNT: *volatile u32 = @ptrFromInt(0xe0001004);
+        const cycles_low = DWT_CYCCNT.*;
+
+        while (SIO_FIFO_ST.* & FIFO_VLD == 0) {}
+        const time_high = SIO_FIFO_RD.*;
+
+        while (SIO_FIFO_ST.* & FIFO_VLD == 0) {}
+        const time_low = SIO_FIFO_RD.*;
+
+        const target_time: i64 = @bitCast(@as(u64, time_high) << 32 | time_low);
+        cycles_offset = target_time - cycles_low;
+        last_cycles = cycles_low;
     }
 }
 
@@ -88,7 +169,7 @@ pub const Pixel = packed struct(u16) {
         }
     }
 
-    pub fn setColor(pixel: *volatile Pixel, color: DisplayColor) void {
+    pub fn setColor(pixel: *Pixel, color: DisplayColor) void {
         pixel.* = fromColor(color);
     }
 };
@@ -118,24 +199,39 @@ const is_wasm = switch (builtin.target.cpu.arch) {
 // (0x20000000) where the OS keeps its own data structures.
 const base = if (is_wasm) 4 else 0x20020004;
 pub const CartIPCData = extern struct {
-    controls: Controls,
-    light_level: u16,
-    neopixels: [5]NeopixelColor,
-    _pad1: [5]u8,
-    red_led: bool,
-    _pad2: u8,
-    battery_level: u16,
-    framebuffers: [2][screen_width][screen_height]Pixel,
-    trace_buf: [0x80]u8,
-    tone_freq: f32,
-    tone_duration: f32,
-    dirty_rect_x: u16,
-    dirty_rect_y: u16,
-    dirty_rect_w: u16,
-    dirty_rect_h: u16,
-    tone_volume: f32,
-    tone_flags: u32,
-    global_volume: f32,
+    // Starting offset is 4
+    controls: Controls, // 4..6
+    light_level: u16,   // 6..8
+    neopixels: [5]NeopixelColor, // 8..x17 bytes
+    _pad1: [5]u8, // x17..x1C
+    red_led: bool, // x1C..x1D
+    _pad2: u8, // x1D..x1E
+    battery_level: u16, // x1E..x20
+    framebuffers: [2][screen_width][screen_height]Pixel, // x20..xA020, xA020..x14020
+    trace_buf: [0x80]u8,// x14020..x140A0
+    tone_freq: f32, // x140A0..x140A4
+    tone_duration: f32, // x140A4..x140A8
+    dirty_rect_x: u16,  // x140A8..x140AA
+    dirty_rect_y: u16,  // x140AA..x140AC
+    dirty_rect_w: u16,  // x140AC..x140AE
+    dirty_rect_h: u16,  // x140AE..x140B0
+    tone_volume: f32,   // x140B0..x140B4
+    tone_flags: u32,    // x140B4..x140B8
+    global_volume: f32, // x140B8..x140BC
+    _pad3: u32,         // x140BC..x140C0
+    tracy_ring: [tracy_buffer_size]u8, // x140C0..x150C0
+    tracy_read_pos: u32,   // x150C0..x150C4
+    _pad4: [3]u32,         // x150C4..x150D0, tracy_read_pos needs its own granule
+    tracy_write_ctrl: u32, // x150D0..x150D4
+    _pad5: [3]u32,         // x150D4..x150E0, tracy_write_ctrl needs its own granule
+    tracy_spinlock: u32,   // x150E0..x150E4
+    _pad6: [3]u32,         // x150E4..x150F0, tracy_spinlock gets its own granule
+
+    comptime {
+        // cart_xip.ld reserves 0x15100 bytes for IPC data.
+        // If it grows more than that, the linker script needs to be updated.
+        std.debug.assert(4 + @sizeOf(CartIPCData) <= 0x15100);
+    }
 };
 const ipc_data: *volatile CartIPCData = @ptrFromInt(base);
 
@@ -148,6 +244,11 @@ pub const battery_level: *volatile u12 = @ptrCast(&ipc_data.battery_level);
 const framebuffer0: *[screen_width][screen_height]Pixel = @volatileCast(&ipc_data.framebuffers[0]);
 const framebuffer1: *[screen_width][screen_height]Pixel = @volatileCast(&ipc_data.framebuffers[1]);
 pub var framebuffer: *[screen_width][screen_height]Pixel = framebuffer0;
+const tracy_ring: [*]u8 = @volatileCast(&ipc_data.tracy_ring);
+const tracy_atomic_write_ctrl: *u32 = @volatileCast(&ipc_data.tracy_write_ctrl);
+const tracy_atomic_read_pos: *u32 = @volatileCast(&ipc_data.tracy_read_pos);
+const tracy_spinlock: *u32 = @volatileCast(&ipc_data.tracy_spinlock);
+var tracy_ref_time: i64 = 0;
 var draw_buffer_index: u1 = 0;
 var has_in_flight_frame: bool = false;
 var present_timeout_events: u32 = 0;
@@ -848,6 +949,339 @@ pub inline fn write_flash_page(page: u16, src: [flash_page_size]u8) void {
     } else {
         // no-op stub: no cart save-data flash region yet
     }
+}
+
+// ┌───────────────────────────────────────────────────────────────────────────┐
+// │                                                                           │
+// │ Profiling Functions                                                       │
+// │                                                                           │
+// └───────────────────────────────────────────────────────────────────────────┘
+
+pub const tracy_buffer_size = 4096;
+
+pub const Zone = struct {
+    pub const inactive: Zone = .{ .active = false };
+
+    active: bool,
+
+    pub inline fn end(z: Zone) void {
+        if (is_wasm or !z.active) return;
+
+        outline_zone_end(cycles(), true);
+    }
+};
+
+pub inline fn fn_zone(comptime loc: std.builtin.SourceLocation) Zone {
+    return zone_color_cond(null, loc, 0, true);
+}
+pub inline fn fn_zone_color(comptime loc: std.builtin.SourceLocation, comptime color: u32) Zone {
+    return zone_color_cond(null, loc, color, true);
+}
+pub inline fn zone(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation) Zone {
+    return zone_color_cond(name, loc, 0, true);
+}
+pub inline fn zone_color(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, comptime color: u32) Zone {
+    return zone_color_cond(name, loc, color, true);
+}
+pub inline fn fn_zone_cond(comptime loc: std.builtin.SourceLocation, active: bool) Zone {
+    return zone_color_cond(null, loc, 0, active);
+}
+pub inline fn fn_zone_color_cond(comptime loc: std.builtin.SourceLocation, comptime color: u32, active: bool) Zone {
+    return zone_color_cond(null, loc, color, active);
+}
+pub inline fn zone_cond(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, active: bool) Zone {
+    return zone_color_cond(name, loc, 0, active);
+}
+pub inline fn zone_color_cond(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, comptime color: u32, active: bool) Zone {
+    // TODO on-demand check connection ID
+    if (is_wasm or !active) return .inactive;
+
+    const src_loc = external_source_location(name, loc, color);
+    return .{ .active = outline_zone_begin_static(cycles(), true, src_loc) };
+}
+
+const external_linksection = ".rodata";
+
+fn StringWrap(comptime str: [:0]const u8) type {
+    return struct {
+        const bytes linksection(external_linksection) = str[0..str.len:0].*;
+    };
+}
+
+inline fn external_string(comptime str: [:0]const u8) [*:0]const u8 {
+    return &StringWrap(str).bytes;
+}
+
+fn SourceLocationWrap(name: ?[:0]const u8, zig_src_loc: std.builtin.SourceLocation, color: u32) type {
+    return struct {
+        pub const src_loc: q.SourceLocationData linksection(external_linksection) = .{
+            .name = if (name) |n| external_string(n) else null,
+            .function = external_string(zig_src_loc.fn_name),
+            .file = external_string(zig_src_loc.file),
+            .line = zig_src_loc.line,
+            .color = color,
+        };
+    };
+}
+
+inline fn external_source_location(comptime name: ?[:0]const u8, comptime zig_src_loc: std.builtin.SourceLocation, comptime color: u32) *const q.SourceLocationData {
+    return &SourceLocationWrap(name, zig_src_loc, color).src_loc;
+}
+
+pub const TracyAtomicWriteCtrl = packed struct (u32) {
+    write_pos: u16,
+    _pad: u12 = 0,
+    server_connected: bool,
+    cart_buffer_active: bool,
+    rtt_buffer_active: bool,
+    has_thread_ctx: bool,
+
+    pub const zero: TracyAtomicWriteCtrl = .{
+        .write_pos = 0,
+        .server_connected = false,
+        .cart_buffer_active = false,
+        .rtt_buffer_active = false,
+        .has_thread_ctx = false,
+    };
+
+    fn inactive(ctrl: TracyAtomicWriteCtrl) bool {
+        return !(ctrl.server_connected and ctrl.cart_buffer_active and ctrl.rtt_buffer_active);
+    }
+};
+
+inline fn ring_available(read_pos: u16, write_pos: u16, size: u16) u16 {
+    return (read_pos -% 1 -% write_pos) & (size-1);
+}
+
+const RingBufferWriter = struct {
+    buf: [*]u8,
+    size: u16,
+    write_pos: u16,
+    read_pos: u16,
+
+    inline fn available(w: *RingBufferWriter) u16 {
+        return ring_available(w.read_pos, w.write_pos, w.size);
+    }
+
+    inline fn write_assume_available(w: *RingBufferWriter, bytes: []const u8) void {
+        const first_len = @min(w.size - w.write_pos, bytes.len);
+        @memcpy(w.buf[w.write_pos..][0..first_len], bytes[0..first_len]);
+        if (first_len < bytes.len) {
+            const second_len = bytes.len - first_len;
+            @memcpy(w.buf[0..second_len], bytes[first_len..]);
+        }
+        w.write_pos = @intCast((w.write_pos +% bytes.len) & (w.size-1));
+    }
+};
+
+inline fn spin_lock_acquire_hw(_: *u32) void {
+    const spinlock: *volatile u32 = @ptrFromInt(0xd0000128);
+    while (spinlock.* == 0) {}
+}
+
+inline fn spin_lock_release_hw(_: *u32) void {
+    const spinlock: *volatile u32 = @ptrFromInt(0xd0000128);
+    spinlock.* = 0;
+}
+
+inline fn spin_lock_acquire_sw(lock: *u32) void {
+    var tmp0: u32 = undefined;
+    var tmp1: u32 = undefined;
+    // Copied from pico SDK spin_lock.h
+    asm volatile (
+        \\ 1: ldaex %[t1], [%[lock]]         // Load the lock value with linked store
+        \\    movs %[t0], #1                 // From PICO: "fill dependency slot" ...?
+        \\    cmp %[t1], #0                  // check if lock is taken
+        \\    bne 1b                         // retry if lock is taken
+        \\    strex %[t1], %[t0], [%[lock]]  // attempt to claim the lock
+         \\   cmp %[t1], #0                 //  check if we got it
+          \\  bne 1b                       //   retry if not
+           //\\ dmb                         //    finally, memory barrier
+        : [t0] "=&r" (tmp0)
+        , [t1] "=&r" (tmp1)
+        : [lock] "r" (lock)
+        : .{ .memory = true }
+    );
+}
+
+inline fn spin_lock_release_sw(lock: *u32) void {
+    const zero: u32 = 0;
+    asm volatile (
+        \\ stl %[zero], [%[lock]] // store with release semantics
+        :
+        : [zero] "r" (zero)
+        , [lock] "r" (lock)
+    );
+}
+
+pub const spin_lock_acquire = spin_lock_acquire_hw;
+pub const spin_lock_release = spin_lock_release_hw;
+
+inline fn cmpxchgStrong(ptr: *volatile u32, expected: u32, new: u32) ?u32 {
+    spin_lock_acquire(tracy_spinlock);
+    defer spin_lock_release(tracy_spinlock);
+
+    const value = ptr.*;
+    if (value != expected) {
+        @branchHint(.unlikely);
+        return value;
+    }
+    ptr.* = new;
+    return null;
+
+    // var actual: u32 = undefined;
+    // var failure: u32 = undefined;
+    // asm volatile (
+    //     \\ 1: ldaex %[actual], [%[ptr]]
+    //     \\    movs %[failure], #1
+    //     \\    cmp %[actual], %[expected]
+    //     \\    bne 1f
+    //     \\    strex %[failure], %[new], [%[ptr]]
+    //     \\    cmp %[failure], #0
+    //     \\    bne 1b
+    //     \\    dmb
+    //     \\ 1:
+    //     : [actual] "=&r" (actual)
+    //     , [failure] "=&r" (failure)
+    //     : [ptr] "r" (ptr)
+    //     , [expected] "r" (expected)
+    //     , [new] "r" (new)
+    //     : .{ .memory = true }
+    // );
+
+    // return if (failure != 0) actual else null;
+    // return @cmpxchgStrong(T, ptr, expected, new, success, fail);
+}
+
+inline fn write_tracy_data_with_delta_time(time: i64, record_block: bool, data_wrapper: anytype) bool {
+    var write_ctrl_word = @atomicLoad(u32, tracy_atomic_write_ctrl, .seq_cst);
+    while (true) {
+        var write_ctrl: TracyAtomicWriteCtrl = @bitCast(write_ctrl_word);
+        if (write_ctrl.inactive()) return false;
+
+        var ref_time = tracy_ref_time;
+        if (!write_ctrl.has_thread_ctx) {
+            @branchHint(.unlikely);
+            ref_time = 0;
+            write_ctrl.has_thread_ctx = true;
+        }
+
+        {
+            const delta = time - ref_time;
+            ref_time = time;
+
+            var writer: RingBufferWriter = .{
+                .buf = tracy_ring,
+                .size = tracy_buffer_size,
+                .write_pos = write_ctrl.write_pos,
+                .read_pos = @truncate(@atomicLoad(u32, tracy_atomic_read_pos, .seq_cst)),
+            };
+
+            const bytes = data_wrapper.set(delta);
+
+            if (writer.available() < bytes.len) {
+                @branchHint(.unlikely);
+
+                if (!record_block) continue;
+                return write_tracy_data_blocking_with_delta_time(time, write_ctrl.write_pos, data_wrapper);
+            }
+
+            writer.write_assume_available(bytes);
+
+            write_ctrl.write_pos = writer.write_pos;
+        }
+
+        write_ctrl_word = if (cmpxchgStrong(tracy_atomic_write_ctrl, write_ctrl_word, @bitCast(write_ctrl))) |v| v else {
+            tracy_ref_time = ref_time;
+            return true;
+        };
+    }
+}
+
+noinline fn write_tracy_data_blocking_with_delta_time(time: i64, write_pos: u16, data_wrapper: anytype) linksection(".ramfunc") bool {
+    const src_loc = external_source_location("Too Much Data!", @src(), 0xDF0F3F);
+
+    // TODO handle graceful data loss rather than blocking
+    const space_needed = data_wrapper.max_size() + @sizeOf(q.Packet(q.ZoneBegin16)) + @sizeOf(q.ZoneEndData);
+    while (true) {
+        // Check if we have space
+        const read_pos = @atomicLoad(u32, tracy_atomic_read_pos, .acquire);
+        if (space_needed <= ring_available(@intCast(read_pos), write_pos, tracy_buffer_size)) break;
+
+        // Check if server disconnected
+        var new_write_ctrl: TracyAtomicWriteCtrl = @bitCast(@atomicLoad(u32, tracy_atomic_write_ctrl, .seq_cst));
+        if (new_write_ctrl.inactive()) return false;
+    }
+
+    // We have space! Record the new delta.
+    // It might be impossible for this loop to actually loop,
+    // but we have it just in case.
+    var write_ctrl_word = @atomicLoad(u32, tracy_atomic_write_ctrl, .seq_cst);
+    while (true) {
+        var write_ctrl: TracyAtomicWriteCtrl = @bitCast(write_ctrl_word);
+        if (write_ctrl.inactive()) return false;
+
+        var ref_time = tracy_ref_time;
+        if (!write_ctrl.has_thread_ctx) {
+            @branchHint(.unlikely);
+            ref_time = 0;
+            write_ctrl.has_thread_ctx = true;
+        }
+
+        {
+            const delta = time - ref_time;
+            ref_time = time;
+
+            var writer: RingBufferWriter = .{
+                .buf = tracy_ring,
+                .size = tracy_buffer_size,
+                .write_pos = write_ctrl.write_pos,
+                .read_pos = @truncate(@atomicLoad(u32, tracy_atomic_read_pos, .seq_cst)),
+            };
+
+            const bytes = data_wrapper.set(delta);
+
+            writer.write_assume_available(bytes);
+
+            const begin = q.packet(.ZoneBegin16, .{ .time = 0, .srcloc = @intFromPtr(src_loc) });
+            writer.write_assume_available(std.mem.asBytes(&begin));
+
+            var end: q.ZoneEndData = undefined;
+            const post_time = cycles();
+            writer.write_assume_available(end.set(post_time - ref_time));
+            ref_time = post_time;
+
+            write_ctrl.write_pos = writer.write_pos;
+        }
+
+        write_ctrl_word = if (cmpxchgStrong(tracy_atomic_write_ctrl, write_ctrl_word, @bitCast(write_ctrl))) |v| v else {
+            tracy_ref_time = ref_time;
+            return true;
+        };
+    }
+}
+
+noinline fn outline_zone_begin_static(time: i64, record_block: bool, src_loc: *const q.SourceLocationData) linksection(".ramfunc") bool {
+    const ZoneBegin = struct {
+        data: q.ZoneBeginData = undefined,
+        src_loc: *const q.SourceLocationData,
+
+        pub fn set(self: *@This(), dt: i64) []const u8 {
+            return self.data.set(dt, self.src_loc);
+        }
+
+        pub fn max_size(_: *@This()) usize {
+            return @sizeOf(q.ZoneBeginData);
+        }
+    };
+
+    var data: ZoneBegin = .{ .src_loc = src_loc };
+    return write_tracy_data_with_delta_time(time, record_block, &data);
+}
+
+noinline fn outline_zone_end(time: i64, record_block: bool) linksection(".ramfunc") void {
+    var data: q.ZoneEndData = undefined;
+    _ = write_tracy_data_with_delta_time(time, record_block, &data);
 }
 
 // ┌───────────────────────────────────────────────────────────────────────────┐

--- a/src/os/cart/cart_entry.zig
+++ b/src/os/cart/cart_entry.zig
@@ -72,8 +72,17 @@ pub fn main() noreturn {
     // mask interrupts on Core 1 to avoid unexpected IRQ vectors in user carts.
     microzig.interrupt.disable_interrupts();
 
+    // Enable cycle counter and sync the timer with the other core for tracy
+    microzig.chip.peripherals.PPB.DWT_CTRL.modify(.{ .CYCCNTENA = 1 });
+    cart_api.os_align_cycles();
+
     start();
     while (true) {
+        // Keep the cycle counter accurate
+        // TODO we could record uS times around each cart call,
+        // to handle any large drift.
+        _ = cart_api.cycles();
+
         update();
         // Signal Core 0 that this frame is complete and wait for the
         // LCD flush to finish before starting the next frame.

--- a/src/os/ipc/mailbox.zig
+++ b/src/os/ipc/mailbox.zig
@@ -138,6 +138,10 @@ pub const MessageType = struct {
     /// Cart writes global volume before sending
     pub const CART_VOLUME: u8 = 0x29;
 
+    pub const SYNC_TIME_REQ_CLR: u32 = 0x2a000001;
+    pub const SYNC_TIME_ACK_CLR: u32 = 0x2a000002;
+    pub const SYNC_TIME_REQ_TIME: u32 = 0x2a000003;
+
     // Application messages (user-defined range: 0x30000000 - 0xFFFFFFFF)
     pub const APP_BASE: Message = 0x30000000;
 

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -60,11 +60,11 @@ var cart_y_pos: u16 = 2;
 // Cart display state
 var last_cart_hash: u32 = 0;
 var cart_hash_accumulator: u32 = 0;
-var display_active: bool = true; // Track if we're showing the cart display
+var cart_display_active: bool = true; // Track if we're showing the cart display
 
 // Cart display check interval (in microseconds) - check every 500ms
 const CART_CHECK_INTERVAL: u64 = 500_000;
-var last_cart_check: u64 = 0;
+var next_cart_check: u64 = 0;
 
 // Stop combo: require both START+SELECT held for 500ms before triggering
 const STOP_COMBO_HOLD_US: u64 = 500_000;
@@ -116,7 +116,9 @@ var ready_fb_state: terry.core0.TrackedStateMachine(enum {
 var ready_framebuffer: []const u16 = undefined;
 var ready_fb_dirty_rect: [4]u16 = undefined;
 
-pub fn main() !void {
+// This function uses FP registers. If inlined into microzig_main, it will save FP registers in the preamble
+// before the FP unit is initialized, causing a fault.
+pub noinline fn main() !void {
     // Initialize all drivers and kernel systems
     try init.init(.{
         .lcd_pins = lcd.createDT018BTFTPins(),
@@ -178,38 +180,10 @@ pub fn main() !void {
                 stop_combo_deadline = timer.micros() + STOP_COMBO_HOLD_US;
             }
             if (timer.micros() > stop_combo_deadline) {
-                console.printf("[BTN] START+SELECT (STOP) pressed (cart_running={})\r\n", .{cart_running});
-                console.println("[STOP] 1: halting Core 1");
-                multicore.haltCore1();
-                console.println("[STOP] 2: stopDMA");
-                lcd.stopDMA();
-                console.println("[STOP] 3a: resetCartBuzzer");
-                audio.reset();
-                console.println("[STOP] 3b: resetCartPWM");
-                gpio.resetCartPWM();
-                console.println("[STOP] 3c: resetCartPIO");
-                gpio.resetCartPIO();
-                console.println("[STOP] 3d: resetCartNeopixels");
-                gpio.resetCartNeopixels();
-                console.println("[STOP] 3e: resetCartLED");
-                gpio.resetCartLED();
-                console.println("[STOP] 3f: initButtons");
-                gpio.initButtons();
-                console.println("[STOP] 4: abortCartChannels");
-                dma.abortCartChannels();
-                console.println("[STOP] 5: loader.stop");
-                loader.stop();
-                console.println("[STOP] 6: resetCore1");
-                multicore.resetCore1();
-                // Mark cart as stopped and restore state before reinit
+                @branchHint(.unlikely);
+
+                stop_active_cart();
                 cart_running = false;
-                display_active = true;
-                btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
-                ready_fb_state.set_state(.not_ready, @src());
-                console.println("[STOP] 8: refreshCartDisplay");
-                refreshCartDisplay();
-                last_cart_hash = computeCartHash();
-                console.println("[STOP] 9: done");
             }
         } else {
             stop_combo_deadline = 0;
@@ -224,160 +198,17 @@ pub fn main() !void {
 
         // Only process navigation buttons when cart is NOT running
         if (!cart_running) {
-            // Joystick up - move cursor up through cart list
-            if (pressed.up) {
-                console.printf("[BTN] UP pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
-                if (cart_count > 0) {
-                    cursor_index = if (cursor_index == 0) cart_count - 1 else cursor_index - 1;
-                    refreshCartDisplay();
-                }
-            }
-
-            // Joystick down - move cursor down through cart list
-            if (pressed.down) {
-                console.printf("[BTN] DOWN pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
-                if (cart_count > 0) {
-                    cursor_index = (cursor_index + 1) % cart_count;
-                    refreshCartDisplay();
-                }
-            }
-
-            // Button A - run the selected cart
-            if (pressed.a) {
-                console.printf("[BTN] A pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
-                if (cart_count > 0 and cursor_index < cart_count) {
-                    runSelectedCart();
-                    continue;
-                } else {
-                    console.printf("[BTN] A: no cart to run (cart_count={d})\r\n", .{cart_count});
-                }
-            }
-
-            const now = timer.micros();
-            if (now > overlay_refresh_deadline) {
-                overlay_refresh_deadline = now + overlay_refresh_period_us;
-                fps_overlay.tick_os();
-            }
-
-            if (fps_overlay.is_drawing() and !lcd.isBusy()) {
-                fps_overlay.submit_lcd_work();
-            }
+            tick_cart_select(pressed);
         } else {
-            // Keep ipc_controls updated every iteration so carts always read fresh
-            // button state (fixes start/select recognition in spaceshooter, metalgear-timer).
-            mailbox.shared_data.controls = buttons;
-
-            // Periodic diagnostic: print raw GPIO reads + processed button state over USB CDC.
-            // Fires on first cart-running entry and then every BTN_DIAG_US microseconds.
-            const now_us = timer.micros();
-            if (!btn_diag_cart_was_running) {
-                btn_diag_cart_was_running = true;
-                btn_diag_last_us = now_us;
-                console.println("[BTN-DIAG] cart started - will log button state every 2s");
-            }
-            if (now_us -% btn_diag_last_us >= BTN_DIAG_US) {
-                btn_diag_last_us = now_us;
-                console.printf("[BTN-DIAG] raw_ipc=0x{x:0>3} | gpio(0=pressed): START={} SEL={} A={} B={} UP={} DN={} \r\n", .{
-                    @as(u16, @bitCast(buttons)),
-                    buttons.start,
-                    buttons.select,
-                    buttons.a,
-                    buttons.b,
-                    buttons.up,
-                    buttons.down,
-                });
-            }
-
-            // Mailbox: process all pending messages (trace, framebuffer sync).
-            // New-API carts send FRAMEBUFFER_READY when they finish a frame.
-            // CART_TRACE: cart debug/panic output via cart.trace().
-            while (mailbox.tryReceive()) |msg| {
-                if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_TRACE) {
-                    const len: usize = @min(mailbox.MessageType.getPayload(msg), mailbox.shared_data.trace_buf.len - 1);
-                    const buf: [*]const u8 = @volatileCast(&mailbox.shared_data.trace_buf);
-                    console.printf("[CART] {s}\r\n", .{buf[0..len]});
-                } else if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_TONE) {
-                    const freq: f32 = mailbox.shared_data.tone_freq;
-                    const duration_sec: f32 = mailbox.shared_data.tone_duration;
-                    const volume = mailbox.shared_data.tone_volume;
-                    const flags = mailbox.shared_data.tone_flags;
-                    audio.tone(freq, duration_sec, volume, flags);
-                } else if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_VOLUME) {
-                    const volume = mailbox.shared_data.global_volume;
-                    audio.set_global_volume(volume);
-                } else if (msg == mailbox.MessageType.FRAMEBUFFER_READY or
-                    mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
-                {
-                    const fb_index: usize = if (mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
-                        @intCast(mailbox.MessageType.getPayload(msg) & 0x1)
-                    else
-                        0;
-                    const is_v2: bool = mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2;
-                    const has_dirty_rect: bool = is_v2 and
-                        (mailbox.MessageType.getPayload(msg) & 0x2) != 0;
-
-                    // Flush selected shared-RAM framebuffer.
-                    fps_overlay.tick_cart();
-                    ready_framebuffer = @ptrCast(@volatileCast(&mailbox.shared_data.framebuffers[fb_index]));
-                    if (has_dirty_rect) {
-                        const rx: u16 = mailbox.shared_data.dirty_rect_x;
-                        const ry: u16 = mailbox.shared_data.dirty_rect_y;
-                        const rw: u16 = mailbox.shared_data.dirty_rect_w;
-                        const rh: u16 = mailbox.shared_data.dirty_rect_h;
-
-                        // Fallback to full-frame if rect metadata is invalid.
-                        if (!(rw == 0 or rh == 0 or rx >= 160 or ry >= 128)) {
-                            ready_fb_dirty_rect = .{ rx, ry, rw, rh };
-                            ready_fb_state.set_state(.ready_rect, @src());
-                        } else {
-                            ready_fb_state.set_state(.ready_whole, @src());
-                        }
-                    } else if (!is_v2) {
-                        // Legacy carts always imply full-frame updates.
-                        ready_fb_state.set_state(.ready_whole, @src());
-                    } else {
-                        // No visual change this frame: skip LCD transfer.
-                        ready_fb_state.set_state(.transferring, @src());
-                    }
-                }
-                // Other messages (e.g. CART_FINISHED) handled by loader state machine.
-            }
-
-            // Dispatch async LCD work
-            if (!lcd.isBusy()) {
-                find_lcd_work: switch (ready_fb_state.state) {
-                    .not_ready => {},
-                    .ready_rect => {
-                        const rect = ready_fb_dirty_rect;
-                        lcd.writeCartBufferRect(ready_framebuffer, rect[0], rect[1], rect[2], rect[3]);
-                        ready_fb_state.set_state(.transferring, @src());
-                    },
-                    .ready_whole => {
-                        lcd.writeCartBuffer(ready_framebuffer);
-                        ready_fb_state.set_state(.transferring, @src());
-                    },
-                    .transferring => {
-                        // Transfer finished, the frame buffer is safe for the app to write
-                        //mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
-                        ready_fb_state.set_state(.draw_debug, @src());
-                        continue :find_lcd_work .draw_debug;
-                    },
-                    .draw_debug => {
-                        if (fps_overlay.is_drawing()) {
-                            fps_overlay.submit_lcd_work();
-                        } else {
-                            mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
-                            ready_fb_state.set_state(.not_ready, @src());
-                        }
-                    },
-                }
-            }
+            tick_cart_mailbox(buttons);
         }
 
-        if (cart_running and display_active) {
+        if (cart_running and cart_display_active) {
+            @branchHint(.unlikely);
             // Cart just started running - stop updating display
-            display_active = false;
-        } else if (!cart_running and !display_active) {
+            cart_display_active = false;
+        } else if (!cart_running and !cart_display_active) {
+            @branchHint(.unlikely);
             // Cart stopped naturally (not via stop button) - reset hardware and restore display.
             btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
             console.printf("[CART] natural stop: state={}, restoring display\r\n", .{loader.getState()});
@@ -388,7 +219,7 @@ pub fn main() !void {
             gpio.resetCartHardware();
             // Abort any DMA transfers the cart may have left running.
             dma.abortCartChannels();
-            display_active = true;
+            cart_display_active = true;
             // Re-sync all button states so any buttons still held when the cart
             // exited are consumed and won't immediately re-trigger menu actions.
             refreshCartDisplay();
@@ -396,18 +227,239 @@ pub fn main() !void {
         }
 
         // Periodically check if cart list changed (only when display is active)
-        if (display_active) {
+        if (cart_display_active) {
             const now = timer.micros();
-            if (now -% last_cart_check >= CART_CHECK_INTERVAL) {
+            if (now >= next_cart_check) {
+                @branchHint(.unlikely);
+
                 const current_hash = computeCartHash();
                 if (current_hash != last_cart_hash) {
                     refreshCartDisplay();
                     last_cart_hash = current_hash;
                 }
-                last_cart_check = now;
+                next_cart_check = now + CART_CHECK_INTERVAL;
             }
         }
     }
+}
+
+fn tick_cart_select(pressed: Controls) void {
+    // Joystick up - move cursor up through cart list
+    if (pressed.up) {
+        @branchHint(.unlikely);
+        console.printf("[BTN] UP pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
+        if (cart_count > 0) {
+            cursor_index = if (cursor_index == 0) cart_count - 1 else cursor_index - 1;
+            refreshCartDisplay();
+        }
+    }
+
+    // Joystick down - move cursor down through cart list
+    if (pressed.down) {
+        @branchHint(.unlikely);
+        console.printf("[BTN] DOWN pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
+        if (cart_count > 0) {
+            cursor_index = (cursor_index + 1) % cart_count;
+            refreshCartDisplay();
+        }
+    }
+
+    // Button A - run the selected cart
+    if (pressed.a) {
+        @branchHint(.unlikely);
+        console.printf("[BTN] A pressed (cursor={d}, cart_count={d})\r\n", .{ cursor_index, cart_count });
+        if (cart_count > 0 and cursor_index < cart_count) {
+            runSelectedCart();
+            return;
+        } else {
+            console.printf("[BTN] A: no cart to run (cart_count={d})\r\n", .{cart_count});
+        }
+    }
+
+    const now = timer.micros();
+    if (now > overlay_refresh_deadline) {
+        @branchHint(.unlikely);
+        overlay_refresh_deadline = now + overlay_refresh_period_us;
+        fps_overlay.tick_os();
+    }
+
+    if (fps_overlay.is_drawing() and !lcd.isBusy()) {
+        fps_overlay.submit_lcd_work();
+    }
+}
+
+fn tick_cart_mailbox(buttons: Controls) void {
+    // Keep ipc_controls updated every iteration so carts always read fresh
+    // button state (fixes start/select recognition in spaceshooter, metalgear-timer).
+    mailbox.shared_data.controls = buttons;
+
+    // Periodic diagnostic: print raw GPIO reads + processed button state over USB CDC.
+    // Fires on first cart-running entry and then every BTN_DIAG_US microseconds.
+    const now_us = timer.micros();
+    if (!btn_diag_cart_was_running) {
+        btn_diag_cart_was_running = true;
+        btn_diag_last_us = now_us;
+        console.println("[BTN-DIAG] cart started - will log button state every 2s");
+    }
+    if (now_us -% btn_diag_last_us >= BTN_DIAG_US) {
+        btn_diag_last_us = now_us;
+        console.printf("[BTN-DIAG] raw_ipc=0x{x:0>3} | gpio(0=pressed): START={} SEL={} A={} B={} UP={} DN={} \r\n", .{
+            @as(u16, @bitCast(buttons)),
+            buttons.start,
+            buttons.select,
+            buttons.a,
+            buttons.b,
+            buttons.up,
+            buttons.down,
+        });
+    }
+
+    // Mailbox: process all pending messages (trace, framebuffer sync).
+    // New-API carts send FRAMEBUFFER_READY when they finish a frame.
+    // CART_TRACE: cart debug/panic output via cart.trace().
+    var sync_time = false;
+    while (mailbox.tryReceive()) |msg| {
+        handle_cart_message(msg, &sync_time);
+    }
+
+    if (sync_time) {
+        sync_cart_time();
+    }
+
+    // Dispatch async LCD work
+    if (!lcd.isBusy()) {
+        find_lcd_work: switch (ready_fb_state.state) {
+            .not_ready => {},
+            .ready_rect => {
+                const rect = ready_fb_dirty_rect;
+                lcd.writeCartBufferRect(ready_framebuffer, rect[0], rect[1], rect[2], rect[3]);
+                ready_fb_state.set_state(.transferring, @src());
+            },
+            .ready_whole => {
+                lcd.writeCartBuffer(ready_framebuffer);
+                ready_fb_state.set_state(.transferring, @src());
+            },
+            .transferring => {
+                // Transfer finished, the frame buffer is safe for the app to write
+                //mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
+                ready_fb_state.set_state(.draw_debug, @src());
+                continue :find_lcd_work .draw_debug;
+            },
+            .draw_debug => {
+                if (fps_overlay.is_drawing()) {
+                    fps_overlay.submit_lcd_work();
+                } else {
+                    mailbox.send(mailbox.MessageType.FRAMEBUFFER_DONE);
+                    ready_fb_state.set_state(.not_ready, @src());
+                }
+            },
+        }
+    }
+}
+
+fn handle_cart_message(msg: u32, sync_time: *bool) void {
+    if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_TRACE) {
+        const len: usize = @min(mailbox.MessageType.getPayload(msg), mailbox.shared_data.trace_buf.len - 1);
+        const buf: [*]const u8 = @volatileCast(&mailbox.shared_data.trace_buf);
+        console.printf("[CART] {s}\r\n", .{buf[0..len]});
+    } else if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_TONE) {
+        const freq: f32 = mailbox.shared_data.tone_freq;
+        const duration_sec: f32 = mailbox.shared_data.tone_duration;
+        const volume = mailbox.shared_data.tone_volume;
+        const flags = mailbox.shared_data.tone_flags;
+        audio.tone(freq, duration_sec, volume, flags);
+    } else if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_VOLUME) {
+        const volume = mailbox.shared_data.global_volume;
+        audio.set_global_volume(volume);
+    } else if (msg == mailbox.MessageType.FRAMEBUFFER_READY or
+        mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
+    {
+        const fb_index: usize = if (mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
+            @intCast(mailbox.MessageType.getPayload(msg) & 0x1)
+        else
+            0;
+        const is_v2: bool = mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2;
+        const has_dirty_rect: bool = is_v2 and
+            (mailbox.MessageType.getPayload(msg) & 0x2) != 0;
+
+        // Flush selected shared-RAM framebuffer.
+        fps_overlay.tick_cart();
+        ready_framebuffer = @ptrCast(@volatileCast(&mailbox.shared_data.framebuffers[fb_index]));
+        if (has_dirty_rect) {
+            const rx: u16 = mailbox.shared_data.dirty_rect_x;
+            const ry: u16 = mailbox.shared_data.dirty_rect_y;
+            const rw: u16 = mailbox.shared_data.dirty_rect_w;
+            const rh: u16 = mailbox.shared_data.dirty_rect_h;
+
+            // Fallback to full-frame if rect metadata is invalid.
+            if (!(rw == 0 or rh == 0 or rx >= 160 or ry >= 128)) {
+                ready_fb_dirty_rect = .{ rx, ry, rw, rh };
+                ready_fb_state.set_state(.ready_rect, @src());
+            } else {
+                ready_fb_state.set_state(.ready_whole, @src());
+            }
+        } else if (!is_v2) {
+            // Legacy carts always imply full-frame updates.
+            ready_fb_state.set_state(.ready_whole, @src());
+        } else {
+            // No visual change this frame: skip LCD transfer.
+            ready_fb_state.set_state(.transferring, @src());
+        }
+    } else if (msg == mailbox.MessageType.SYNC_TIME_REQ_CLR) {
+        sync_time.* = true;
+    }
+    // Other messages (e.g. CART_FINISHED) handled by loader state machine.
+}
+
+fn stop_active_cart() void {
+    console.println("[BTN] START+SELECT (STOP) pressed");
+    console.println("[STOP] 1: halting Core 1");
+    multicore.haltCore1();
+    console.println("[STOP] 2: stopDMA");
+    lcd.stopDMA();
+    console.println("[STOP] 3a: resetCartBuzzer");
+    audio.reset();
+    console.println("[STOP] 3b: resetCartPWM");
+    gpio.resetCartPWM();
+    console.println("[STOP] 3c: resetCartPIO");
+    gpio.resetCartPIO();
+    console.println("[STOP] 3d: resetCartNeopixels");
+    gpio.resetCartNeopixels();
+    console.println("[STOP] 3e: resetCartLED");
+    gpio.resetCartLED();
+    console.println("[STOP] 3f: initButtons");
+    gpio.initButtons();
+    console.println("[STOP] 4: abortCartChannels");
+    dma.abortCartChannels();
+    console.println("[STOP] 5: loader.stop");
+    loader.stop();
+    console.println("[STOP] 6: resetCore1");
+    multicore.resetCore1();
+    // Mark cart as stopped and restore state before reinit
+    cart_display_active = true;
+    btn_diag_cart_was_running = false; // reset so next cart launch emits "cart started"
+    ready_fb_state.set_state(.not_ready, @src());
+    console.println("[STOP] 8: refreshCartDisplay");
+    refreshCartDisplay();
+    last_cart_hash = computeCartHash();
+    console.println("[STOP] 9: done");
+}
+
+fn sync_cart_time() void {
+    const cs = microzig.interrupt.enter_critical_section();
+    defer cs.leave();
+
+    mailbox.send(mailbox.MessageType.SYNC_TIME_ACK_CLR);
+
+    const msg = while (true) {
+        if (mailbox.tryReceive()) |msg| break msg;
+    };
+
+    const time: u64 = @bitCast(terry.client.get_time_core0(cs));
+    mailbox.send(@intCast(time >> 32));
+    mailbox.send(@truncate(time));
+
+    std.debug.assert(msg == mailbox.MessageType.SYNC_TIME_REQ_TIME);
 }
 
 /// Compute a simple hash of cart list to detect changes
@@ -587,6 +639,8 @@ fn runSelectedCart() void {
     // Carts read at start of update(); this ensures frame 0 sees real buttons
     // rather than all-zero (which broke metalgear-timer and spaceshooter).
     mailbox.shared_data.controls = read_buttons();
+    @memset(std.mem.asBytes(&mailbox.shared_data.framebuffers), 0);
+    terry.client.prepare_for_cart();
 
     // Execute the cart
     console.println("[BTN] calling executeCart...");
@@ -594,11 +648,11 @@ fn runSelectedCart() void {
         // Cart execution started successfully
         // Mark as running immediately to prevent race conditions
         loader.markRunning();
-        // NOTE: do NOT set display_active = false here. cart_running is still false
+        // NOTE: do NOT set cart_display_active = false here. cart_running is still false
         // in this loop iteration (it was captured before runSelectedCart was called),
-        // so setting display_active = false here causes the !cart_running && !display_active
+        // so setting cart_display_active = false here causes the !cart_running && !cart_display_active
         // branch to fire immediately, redrawing the menu on top of the cart.
-        // The main loop's (cart_running && display_active) check handles this correctly
+        // The main loop's (cart_running && cart_display_active) check handles this correctly
         // on the next iteration once cart_running reflects the new state.
         console.println("[BTN] executeCart succeeded, cart running");
         // Small delay to let Core 1 start and take control of hardware

--- a/src/os/system/fps_overlay.zig
+++ b/src/os/system/fps_overlay.zig
@@ -17,6 +17,7 @@ var last_frame_us: u64 = 0;
 
 /// Timestamp (µs) of the most recent poll() call.
 var last_poll_us: u64 = 0;
+var last_xip_sample_cycles: u32 = 0;
 
 /// Time spent mixing audio
 var audio_pct_sample_start: u64 = 0;
@@ -24,6 +25,10 @@ var audio_mix_count: u32 = 0;
 var audio_mix_total_us: u32 = 0;
 var audio_mix_max_us: u32 = 0;
 var audio_service_delay_max_us: u32 = 0;
+
+/// XIP Stats
+var xip_hit_rate: u32 = 0;
+var xip_stall_rate: u32 = 0;
 
 // ── Rolling averages ───────────────────────────────────────────────────────────
 // multi-sample ring buffer so the display doesn't jitter on minor frame-time
@@ -222,6 +227,21 @@ pub fn poll() void {
 
     if (audio_pct_sample_start == 0) {
         audio_pct_sample_start = now;
+
+        {
+            const cs = microzig.interrupt.enter_critical_section();
+            defer cs.leave();
+
+            microzig.chip.peripherals.PPB.DWT_CTRL.modify(.{ .CYCCNTENA = 1 });
+            microzig.chip.peripherals.PPB.DEMCR.modify(.{ .TRCENA = 1 });
+
+            microzig.chip.peripherals.BUSCTRL.PERFSEL0.write(.{ .PERFSEL0 = .xip_main0_stall_downstream });
+            microzig.chip.peripherals.BUSCTRL.PERFSEL1.write(.{ .PERFSEL1 = .xip_main1_stall_downstream });
+            microzig.chip.peripherals.BUSCTRL.PERFCTR_EN.write(.{ .PERFCTR_EN = 1 });
+            last_xip_sample_cycles = microzig.chip.peripherals.PPB.DWT_CYCCNT.raw;
+            microzig.chip.peripherals.BUSCTRL.PERFCTR0.write_raw(0);
+            microzig.chip.peripherals.BUSCTRL.PERFCTR1.write_raw(0);
+        }
     } else if (now - audio_pct_sample_start >= 150_000) {
         const total_time = time_delta(audio_pct_sample_start, now);
         const audio_time = audio_mix_total_us;
@@ -239,6 +259,32 @@ pub fn poll() void {
         audio_mix_max_us = 0;
         audio_service_delay_max_us = 0;
         audio_pct_sample_start = now;
+
+        var xip_hit: u32 = undefined;
+        var xip_acc: u32 = undefined;
+        var xip_stall_0: u32 = undefined;
+        var xip_stall_1: u32 = undefined;
+        var cycles: u32 = undefined;
+        {
+            const cs = microzig.interrupt.enter_critical_section();
+            defer cs.leave();
+
+            xip_hit = microzig.chip.peripherals.XIP_CTRL.CTR_HIT.raw;
+            microzig.chip.peripherals.XIP_CTRL.CTR_HIT.write_raw(0);
+            xip_acc = microzig.chip.peripherals.XIP_CTRL.CTR_ACC.raw;
+            microzig.chip.peripherals.XIP_CTRL.CTR_ACC.write_raw(0);
+
+            xip_stall_0 = microzig.chip.peripherals.BUSCTRL.PERFCTR0.raw;
+            xip_stall_1 = microzig.chip.peripherals.BUSCTRL.PERFCTR1.raw;
+            cycles = microzig.chip.peripherals.PPB.DWT_CYCCNT.raw;
+            microzig.chip.peripherals.BUSCTRL.PERFCTR0.write_raw(0);
+            microzig.chip.peripherals.BUSCTRL.PERFCTR1.write_raw(0);
+        }
+        xip_hit_rate = if (xip_acc == 0) 0 else @intFromFloat(9999.0 * @as(f32, @floatFromInt(xip_hit)) / @as(f32, @floatFromInt(xip_acc)));
+        const delta_cycles = cycles -% last_xip_sample_cycles;
+        xip_stall_rate = if (delta_cycles == 0) 0 else @intFromFloat(9999.0 * @as(f32, @floatFromInt(xip_stall_0 + xip_stall_1)) / @as(f32, @floatFromInt(delta_cycles)));
+
+        last_xip_sample_cycles = cycles;
     }
 
     last_poll_us = now;
@@ -312,6 +358,16 @@ fn add_os_debug_text() void {
     const poll_max_max = poll_max_history.max();
     const max_pps_str = std.fmt.bufPrint(&buf, "{d:>4}", .{poll_max_max}) catch "????";
     add_debug_text(.{ .text = max_pps_str, .x = @intCast(lcd.width - (4 * font_width)), .y = 8, .alignment = .right, .color = lcd.RED });
+
+    if (xip_hit_rate != 0) {
+        const xip_str = std.fmt.bufPrint(&buf, "{d:0>4}", .{xip_hit_rate}) catch "????";
+        add_debug_text(.{ .text = xip_str, .x = lcd.width, .y = 16, .alignment = .right, .color = lcd.GREEN });
+    }
+
+    if (xip_stall_rate != 0) {
+        const xip_str = std.fmt.bufPrint(&buf, "{d:0>4}", .{xip_stall_rate}) catch "????";
+        add_debug_text(.{ .text = xip_str, .x = lcd.width - (4 * font_width), .y = 16, .alignment = .right, .color = lcd.RED });
+    }
 
     if (rev.debug) {
         // Revision strings

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -213,7 +213,7 @@ pub fn init(config: InitConfig) !void {
             while (true) {
                 terry.client.poll();
                 if (!terry.client.is_waiting_for_connection()) break;
-                if (timer.millis() > deadline) break;
+                if (timer.micros() > deadline) break;
             }
         }
     }

--- a/src/os/system/terry.zig
+++ b/src/os/system/terry.zig
@@ -1,5 +1,5 @@
 pub const client = @import("terry_client.zig");
-const q = @import("terry_protocol.zig");
+const q = @import("tracy_protocol.zig");
 
 const mz_rtt = @import("../drivers/microzig_rtt.zig");
 const rtt = @import("../drivers/rtt.zig");
@@ -139,7 +139,7 @@ pub const core0 = struct {
         return zone_color_cond(name, loc, 0, true);
     }
     pub inline fn zone_color(comptime name: ?[:0]const u8, comptime loc: std.builtin.SourceLocation, comptime color: u32) Zone {
-        return zone_color_cond(external_source_location(name, loc, color), true);
+        return zone_color_cond(name, loc, color, true);
     }
     pub inline fn fn_zone_cond(comptime loc: std.builtin.SourceLocation, active: bool) Zone {
         return zone_color_cond(null, loc, 0, active);

--- a/src/os/system/terry_client.zig
+++ b/src/os/system/terry_client.zig
@@ -1,7 +1,7 @@
 /// Terry is a reimplementation of the Tracy 0.14.0 client designed for a
 /// low-memory threadless microcontroller environment with RTT output.
 const terry = @import("terry.zig");
-const q = @import("terry_protocol.zig");
+const q = @import("tracy_protocol.zig");
 
 const timer = @import("../drivers/timer.zig");
 const rev = @import("../drivers/rev.zig");
@@ -74,6 +74,12 @@ const core0_thread_id_ptr = terry.external_string("Core 0 (OS)");
 pub fn core0_thread_id() u32 {
     return @intFromPtr(core0_thread_id_ptr);
 }
+
+// TODO send events to update this thread name to match the name
+// of whatever cart is running.
+const cart_thread_id_ptr = terry.external_string("Core 1 (Cart)");
+fn cart_thread_id() u32 { return @intFromPtr(cart_thread_id_ptr); }
+
 
 pub var core0_thread_ref_time: i64 = 0;
 pub var has_core0_thread_context: bool = false;
@@ -993,9 +999,19 @@ pub fn is_buffer_full() bool {
 }
 
 pub fn try_resume_data(time: i64) bool {
-    const resume_safety_margin = 128;
-    const necessary_bytes = core0_compute_bulk_begin_len(core0_num_zones) + resume_safety_margin + reserved_space_post_bulk_begin();
+    const resume_safety_margin = 1024;
+
+    const necessary_bytes = cart_reserved_size +
+        core0_compute_bulk_begin_len(core0_num_zones) +
+        resume_safety_margin +
+        reserved_space_post_bulk_begin();
+
     if (send.available_space() >= necessary_bytes) {
+        if (cart_reserved_size != 0) {
+            send_core1_assume_available(wire_layout(@sizeOf(q.Packet(q.ThreadContext)) + cart_pending_read_size), cart_pending_read_size);
+            cart_pending_read_size = 0;
+            cart_reserved_size = 0;
+        }
         core0_emit_bulk_begin(time);
         state = .connected;
         return true;
@@ -1016,13 +1032,21 @@ pub fn poll() void {
 
     dispatch: switch (state) {
         .uninitialized => {
+            // Enable cycle counter clock
             microzig.chip.peripherals.PPB.DWT_CTRL.modify(.{ .CYCCNTENA = 1 });
+            microzig.chip.peripherals.PPB.DEMCR.modify(.{ .TRCENA = 1 });
+
             startup_time = get_time_core0(undefined);
+            prepare_for_cart(); // initialize cart ring buffer vars
+
             log("TERRY: .uninitialized => .wait_for_server\n");
             state = .wait_for_server;
             continue :dispatch state;
         },
         .wait_for_server => {
+            if (support_on_demand) {
+                clear_queues();
+            }
             // TODO more robust shibboleth handling is necessary for on-demand,
             // where there might be junk from the previous connection before
             // the shibboleth, which could offset the rtt stream arbitrarily.
@@ -1030,14 +1054,17 @@ pub fn poll() void {
             // clear it if not found.
             var shibboleth: [q.HandshakeShibboleth.len]u8 = undefined;
             if (recv.read_if_available(&shibboleth)) {
+                @branchHint(.unlikely);
+
                 if (std.mem.eql(u8, &shibboleth, q.HandshakeShibboleth)) {
                     log("TERRY: .wait_for_server => .handshake\n");
                     state = .handshake;
+                    continue :dispatch state;
                 } else {
                     log("TERRY: invalid shibboleth! => .terminal\n");
                     state = .terminal;
+                    continue :dispatch state;
                 }
-                continue :dispatch state;
             }
         },
         .handshake => {
@@ -1074,6 +1101,7 @@ pub fn poll() void {
 
             // Make sure we have enough space for some data and a bulk end before starting
             std.debug.assert(core0_num_zones == 0); // TODO on-demand this might not be true on reconnect, might need special handling
+            std.debug.assert(cart_reserved_size == 0);
             if (send.available_space() < 128 + core0_compute_sm_bulk_declare_len() + reserved_space_post_bulk_begin()) {
                 return;
             }
@@ -1087,6 +1115,9 @@ pub fn poll() void {
             }
             @atomicStore(bool, &atomic_is_connected, true, .release);
 
+            // Enable cart recording
+            _ = @atomicRmw(u32, cart_atomic_write_ctrl, .Or, set_connected_mask, .acq_rel);
+
             interrupt_trace_enabled = true;
             last_keep_alive_us = timer.micros();
             log("TERRY: .new_connection => .connected\n");
@@ -1094,16 +1125,27 @@ pub fn poll() void {
             continue :dispatch state;
         },
         .connected => {
+            // First priority: server query responses
             try_send_packet();
             if (state != .connected) {
+                @branchHint(.unlikely);
                 continue :dispatch state;
             }
 
             if (!disconnect_requested) {
+                @branchHint(.likely);
+
                 do_systime();
                 do_syspower();
-                // TODO round-robin to avoid serial queue starvation deadlock?
-                send_core1_queue();
+
+                const cs = microzig.interrupt.enter_critical_section();
+                defer cs.leave();
+
+                // Second priority: Cart queue
+                if (!send_core1_queue()) {
+                    data_overflow(get_time_core0(cs));
+                }
+
                 send_serial_queue();
             } else {
                 clear_queues();
@@ -1117,78 +1159,34 @@ pub fn poll() void {
             while (pending_packet_type == .no_packet and state == .connected) {
                 // TODO maybe put a deadline here to avoid very long polls handling a chatty server
 
-                if (!recv.read_if_available(std.mem.asBytes(&query))) break;
-
-                logf("TERRY: server query: {s}\n", .{@tagName(query.type)});
-
-                switch (query.type) {
-                    .ServerQueryString => send_string_ptr(query.ptr, .StringData, .server_query),
-                    .ServerQueryPlotName => send_string_ptr(query.ptr, .PlotName, .server_query),
-                    .ServerQueryFrameName => send_string_ptr(query.ptr, .FrameName, .server_query),
-                    .ServerQueryFiberName => send_string_ptr(query.ptr, .FiberName, .server_query),
-
-                    // Normally query.ptr for ServerQueryThreadString would be a TID, but since we don't
-                    // have TIDs, Terry uses pointers to the name string as its the thread identifier.
-                    // Note that this is also used for Tracked State Machine names, which are tracked as if they were threads.
-                    .ServerQueryThreadString => send_string_ptr(query.ptr, .ThreadName, .server_query),
-
-                    .ServerQueryExternalName => send_string(query.ptr, "???", .ExternalThreadName, .external_name_pt1), // External name request sends two strings in response
-
-                    .ServerQuerySourceLocation => send_src_loc(query.ptr, .server_query),
-
-                    .ServerQueryCallstackFrame => send_empty(.AckServerQueryNoop, .server_query), // no symbol info
-                    .ServerQuerySymbol => send_empty(.AckServerQueryNoop, .server_query),
-                    .ServerQuerySymbolCode => send_empty(.AckSymbolCodeNotAvailable, .server_query),
-                    .ServerQuerySourceCode => send_empty(.AckSourceCodeNotAvailable, .server_query),
-
-                    // Query data is only used by source code queries, which we don't support.
-                    // So just pretend we're recording it, but we can ignore the data.
-                    .ServerQueryDataTransfer => send_empty(.AckServerQueryNoop, .server_query),
-                    .ServerQueryDataTransferPart => send_empty(.AckServerQueryNoop, .server_query),
-
-                    .ServerQueryParameter => {
-                        const param_idx: u32 = @intCast(query.ptr >> 32);
-                        const param_val: i32 = @bitCast(@as(u32, @truncate(query.ptr)));
-                        if (param_callback_fn) |func| {
-                            func(param_callback_obj, param_idx, param_val);
-                        }
-                        send_empty(.AckServerQueryNoop, .server_query);
-                    },
-
-                    // Disconnect is a handshake.
-                    // Server sends Disconnect, client sends Terminate, server sends Terminate.
-                    // Client can also send Terminate unprompted, which may result in the server
-                    // sending Terminate back.
-                    .ServerQueryDisconnect => {
-                        disconnect_requested = true;
-                        send_empty(.Terminate, .server_query);
-                    },
-                    .ServerQueryTerminate => {
-                        state = .terminating;
-                        continue :dispatch state;
-                    },
-                    _ => {
-                        // TODO any special error handling to do here?
-                        std.debug.assert(false);
-                    },
+                if (!recv.read_if_available(std.mem.asBytes(&query))) {
+                    @branchHint(.likely);
+                    break;
                 }
 
-                try_send_packet();
-                if (state != .connected) {
+                handle_server_query(&query);
+
+                if (state == .terminating) {
                     continue :dispatch state;
                 }
             }
         },
 
         .buffer_full => {
-            clear_queues();
-            const time = get_time_core0(undefined);
-            if (try_resume_data(time)) {
-                continue :dispatch .connected;
+            // Try to send pending core1 data
+            if (send_core1_queue()) {
+                // If that worked, try to resume OS data
+                const time = get_time_core0(undefined);
+                if (try_resume_data(time)) {
+                    continue :dispatch .connected;
+                }
             }
         },
 
         .terminating => {
+            // Disable cart recording
+            _ = @atomicRmw(u32, cart_atomic_write_ctrl, .And, ~set_connected_mask, .acq_rel);
+
             @atomicStore(bool, &atomic_is_connected, false, .release);
             if (support_on_demand) {
                 // TODO the server might send trailing packets before signing off, we need to
@@ -1248,9 +1246,76 @@ pub fn poll() void {
     }
 }
 
-fn try_send_packet() void {
-    if (pending_packet_type == .no_packet) return;
+noinline fn handle_server_query(query: *const q.ServerQueryPacket) void {
+    const z = terry.core0.fn_zone(@src()); defer z.end();
 
+    logf("TERRY: server query: {s}\n", .{@tagName(query.type)});
+
+    switch (query.type) {
+        .ServerQueryString => send_string_ptr(query.ptr, .StringData, .server_query),
+        .ServerQueryPlotName => send_string_ptr(query.ptr, .PlotName, .server_query),
+        .ServerQueryFrameName => send_string_ptr(query.ptr, .FrameName, .server_query),
+        .ServerQueryFiberName => send_string_ptr(query.ptr, .FiberName, .server_query),
+
+        // Normally query.ptr for ServerQueryThreadString would be a TID, but since we don't
+        // have TIDs, Terry uses pointers to the name string as its the thread identifier.
+        // Note that this is also used for Tracked State Machine names, which are tracked as if they were threads.
+        .ServerQueryThreadString => send_string_ptr(query.ptr, .ThreadName, .server_query),
+
+        .ServerQueryExternalName => send_string(query.ptr, "???", .ExternalThreadName, .external_name_pt1), // External name request sends two strings in response
+
+        .ServerQuerySourceLocation => send_src_loc(query.ptr, .server_query),
+
+        .ServerQueryCallstackFrame => send_empty(.AckServerQueryNoop, .server_query), // no symbol info
+        .ServerQuerySymbol => send_empty(.AckServerQueryNoop, .server_query),
+        .ServerQuerySymbolCode => send_empty(.AckSymbolCodeNotAvailable, .server_query),
+        .ServerQuerySourceCode => send_empty(.AckSourceCodeNotAvailable, .server_query),
+
+        // Query data is only used by source code queries, which we don't support.
+        // So just pretend we're recording it, but we can ignore the data.
+        .ServerQueryDataTransfer => send_empty(.AckServerQueryNoop, .server_query),
+        .ServerQueryDataTransferPart => send_empty(.AckServerQueryNoop, .server_query),
+
+        .ServerQueryParameter => {
+            const param_idx: u32 = @intCast(query.ptr >> 32);
+            const param_val: i32 = @bitCast(@as(u32, @truncate(query.ptr)));
+            if (param_callback_fn) |func| {
+                func(param_callback_obj, param_idx, param_val);
+            }
+            send_empty(.AckServerQueryNoop, .server_query);
+        },
+
+        // Disconnect is a handshake.
+        // Server sends Disconnect, client sends Terminate, server sends Terminate.
+        // Client can also send Terminate unprompted, which may result in the server
+        // sending Terminate back.
+        .ServerQueryDisconnect => {
+            disconnect_requested = true;
+            send_empty(.Terminate, .server_query);
+        },
+        .ServerQueryTerminate => {
+            state = .terminating;
+            return;
+        },
+        _ => {
+            // TODO any special error handling to do here?
+            std.debug.assert(false);
+        },
+    }
+
+    try_send_packet();
+}
+
+inline fn try_send_packet() void {
+    if (pending_packet_type == .no_packet) {
+        @branchHint(.likely);
+        return;
+    }
+
+    outline_try_send_packet();
+}
+
+noinline fn outline_try_send_packet() void {
     const ty = tmp_packet_as(q.Type).*;
     const packet_size = q.PacketSize[@backingInt(ty)];
     const data_size = packet_size + tmp_packet_data.len;
@@ -1389,14 +1454,146 @@ fn send_empty(ty: q.Type, pending_ty: PendingPacket) void {
     logf("TERRY: send_empty .{s} => .{s}\n", .{ @tagName(ty), @tagName(pending_packet_type) });
 }
 
+const ipc_data = @import("../ipc/mailbox.zig").shared_data;
+const cart_api = @import("../cart/api.zig");
+const TracyAtomicWriteCtrl = cart_api.TracyAtomicWriteCtrl;
+const cart_ring_size = cart_api.tracy_buffer_size;
+const cart_ring_mask = cart_ring_size-1;
+// Debug: x/[len]xb 0x200340C0
+const cart_ring: *[cart_ring_size]u8 = @volatileCast(&ipc_data.tracy_ring);
+// Debug: watch *(u32*)0x200350C4
+const cart_atomic_write_ctrl: *u32 = @volatileCast(&ipc_data.tracy_write_ctrl);
+// Debug: watch *(u32*)0x200350C0
+const cart_atomic_read_pos: *u32 = @volatileCast(&ipc_data.tracy_read_pos);
+const cart_spinlock: *u32 = @volatileCast(&ipc_data.tracy_spinlock);
+var cart_reserved_size: u32 = 0;
+var cart_pending_read_size: u32 = 0;
+
+const unset_thread_ctx_mask: u32 = blk: {
+    var ctrl: TracyAtomicWriteCtrl = @bitCast(~@as(u32, 0));
+    ctrl.has_thread_ctx = false;
+    break :blk @bitCast(ctrl);
+};
+
+const set_connected_mask: u32 = blk: {
+    var ctrl: TracyAtomicWriteCtrl = @bitCast(@as(u32, 0));
+    ctrl.server_connected = true;
+    break :blk @bitCast(ctrl);
+};
+
 fn clear_queues() void {
-    // TODO once we have multiple threads, this function should
-    // dequeue and throw away any data from other threads,
-    // to prevent them from blocking on a full queue.
+    // Empty the cart queue, discarding all data.
+    //const write_ctrl: TracyAtomicWriteCtrl = @bitCast(@atomicRmw(u32, cart_atomic_write_ctrl, .And, ~set_connected_mask, .acq_rel));
+    const write_ctrl: TracyAtomicWriteCtrl = @bitCast(@atomicLoad(u32, cart_atomic_write_ctrl, .seq_cst));
+    @atomicStore(u32, cart_atomic_read_pos, write_ctrl.write_pos, .release);
+    cart_pending_read_size = 0;
+    cart_reserved_size = 0;
 }
 
-fn send_core1_queue() void {
-    // TODO copy data from the Core 1 queue to the RTT port
+pub fn prepare_for_cart() void {
+    @memset(cart_ring, 0);
+    const initial_write_control: TracyAtomicWriteCtrl = .{
+        .write_pos = 0,
+        .server_connected = is_connected_core0(),
+        .cart_buffer_active = true, // TODO handle cart running out of buffer space
+        .rtt_buffer_active = true, // TODO handle RTT full for cart
+        .has_thread_ctx = false,
+    };
+    @atomicStore(u32, cart_atomic_write_ctrl, @bitCast(initial_write_control), .release);
+    @atomicStore(u32, cart_atomic_read_pos, 0, .seq_cst);
+    cart_api.spin_lock_release(cart_spinlock);
+}
+
+fn send_core1_assume_available(layout: WireLayout, data_len: usize) void {
+    std.debug.assert(layout.data_bytes == @sizeOf(q.Packet(q.ThreadContext)) + data_len);
+
+    var read_pos = @atomicLoad(u32, cart_atomic_read_pos, .unordered); // only this core modifies read_pos
+
+    var cursor = write_header_assume_available(layout);
+    const first_len = @min(data_len, cart_ring_size - read_pos);
+    const thread_ctx = q.packet(.ThreadContext, .{ .thread = cart_thread_id() });
+    cursor.write_assume_available(std.mem.asBytes(&thread_ctx));
+    cursor.write_assume_available(cart_ring[read_pos..read_pos+first_len]);
+    if (first_len < data_len) {
+        cursor.write_assume_available(cart_ring[0..data_len - first_len]);
+    }
+    cursor.commit();
+
+    read_pos = (read_pos + data_len) & cart_ring_mask;
+    @atomicStore(u32, cart_atomic_read_pos, read_pos, .release);
+
+    has_core0_thread_context = false;
+}
+
+fn send_core1_queue() bool {
+    if (cart_reserved_size != 0) {
+        @branchHint(.unlikely);
+
+        std.debug.assert(is_buffer_full());
+
+        if (cart_reserved_size > available_space_with_reservation()) return false;
+
+        const layout = wire_layout(@sizeOf(q.Packet(q.ThreadContext)) + cart_pending_read_size);
+        std.debug.assert(layout.total_bytes == cart_reserved_size);
+
+        send_core1_assume_available(layout, cart_pending_read_size);
+        cart_pending_read_size = 0;
+        cart_reserved_size = 0;
+    }
+
+    // non-atomically estimate the available size, and skip if the buffer isn't full enough
+    // Note for testing atomics: Disable this to get more collisions. Don't forget to enable to_read == 0 check below!
+    const estimated_write_pos = @as(*volatile u32, cart_atomic_write_ctrl).* & 0xFFFF;
+    const read_pos = @atomicLoad(u32, cart_atomic_read_pos, .unordered); // only this core modifies read_pos
+
+    const estimated_to_read = (estimated_write_pos -% read_pos) & cart_ring_mask;
+    const minimum_to_read = cart_ring_size / 4;
+    if (estimated_to_read < minimum_to_read) {
+        @branchHint(.likely);
+        return true;
+    }
+
+    // Once this is observed, it has to be sent as a packet, as we atomically set the thread context
+    // mask meaning that we will insert a thread context. We must now split packets on this boundary.
+    var write_ctrl: TracyAtomicWriteCtrl = undefined;
+    {
+        cart_api.spin_lock_acquire(cart_spinlock);
+        defer cart_api.spin_lock_release(cart_spinlock);
+
+        write_ctrl = @bitCast(@as(*volatile u32, cart_atomic_write_ctrl).*);
+        write_ctrl.has_thread_ctx = false;
+        @as(*volatile u32, cart_atomic_write_ctrl).* = @bitCast(write_ctrl);
+
+        // var write_ctrl_bits: u32 = undefined;
+        // var tmp0: u32 = undefined;
+        // asm volatile (
+        //     \\ 1: ldaex %[value], [%[ptr]]
+        //     \\    bic %[value], %[value], #0x80000000
+        //     \\    strex %[t0], %[value], [%[ptr]]
+        //     \\    cmp %[t0], #0
+        //     \\    bne 1b
+        //     \\    dmb
+        //     : [value] "=&r" (write_ctrl_bits)
+        //     , [t0] "=&r" (tmp0)
+        //     : [ptr] "r" (cart_atomic_write_ctrl)
+        //     : .{ .memory = true }
+        // );
+
+        //const write_ctrl_bits = @atomicRmw(u32, cart_atomic_write_ctrl, .And, unset_thread_ctx_mask, .seq_cst);
+    }
+    //const write_ctrl: TracyAtomicWriteCtrl = @bitCast(write_ctrl_bits);
+    const to_read = (write_ctrl.write_pos -% read_pos) & cart_ring_mask;
+    // if (to_read == 0) return true;
+
+    const layout = wire_layout(@sizeOf(q.Packet(q.ThreadContext)) + to_read);
+    if (layout.total_bytes <= available_space_with_reservation()) {
+        send_core1_assume_available(layout, to_read);
+        return true;
+    } else {
+        cart_pending_read_size = to_read;
+        cart_reserved_size = layout.total_bytes;
+        return false;
+    }
 }
 
 fn send_serial_queue() void {

--- a/src/os/system/tracy_protocol.zig
+++ b/src/os/system/tracy_protocol.zig
@@ -807,6 +807,10 @@ pub const ZoneBeginData = extern union {
             return std.mem.asBytes(&data.zone_64);
         }
     }
+
+    pub fn max_size(_: *@This()) usize {
+        return @sizeOf(@This());
+    }
 };
 
 pub const ZoneEndData = extern union {
@@ -828,6 +832,10 @@ pub const ZoneEndData = extern union {
             data.* = .{ .zone_64 = .{ .ty = .ZoneEnd, .data = .{ .time = dt - ProtocolOffset32Bit } } };
             return std.mem.asBytes(&data.zone_64);
         }
+    }
+
+    pub fn max_size(_: *@This()) usize {
+        return @sizeOf(@This());
     }
 };
 


### PR DESCRIPTION
*note: Requires all carts to be recompiled, as it moves their memory space.

Adds tracy zone APIs for carts to use. Terry prioritizes cart data over OS data, and will maintain data sends over RTT even when saturated. For now, the cart client will block if the buffer of tracy events is full. It will record a zone when this happens to show the blockage.

This PR also adds performance counters for the XIP cache.