### PR TITLE
Fix display washout and dim the backlight

### DIFF
--- a/src/board_v2.zig
+++ b/src/board_v2.zig
@@ -37,7 +37,7 @@ pub const TFT_SCK = gpio.num(18); // SPI0 SCK
 pub const TFT_MOSI = gpio.num(19); // SPI0 TX (SDIO)
 // pub const TFT_RST = gpio.num(21); // Reset (GPIO), tied to hardware
 pub const TFT_DC = gpio.num(21); // Data/Command (GPIO)
-pub const BKLT_PWM = gpio.num(16); // Backlight PWM (controls LED_K1 and LED_K2)
+pub const BKLT_PWM = gpio.num(16); // Backlight PWM (controls LED_K1 and LED_K2, see os/drivers/backlight.zig)
 pub const LCD_TE = gpio.num(20); // LCD Tearing Effect output (GPIO input, optional for sync)
 // Note: TFT_LITE (backlight) connected directly to VBUS (5V)
 // Note: SPI4W tied to 3V3 (High = 4-wire SPI mode)

--- a/src/os/drivers/backlight.zig
+++ b/src/os/drivers/backlight.zig
@@ -1,0 +1,39 @@
+/// Backlight brightness for the SYCL Badge V2 display.
+/// GPIO16 switches the panel's LED cathodes, so a PWM duty cycle sets brightness.
+const microzig = @import("microzig");
+const board = microzig.board;
+const pwm = microzig.hal.pwm;
+
+/// GPIO16 is on PWM slice 0, channel A. The mux repeats its PWM slots every 16
+/// pins below GPIO32, so the slice is (16 >> 1) & 7, not 16 / 2.
+const backlight_slice: pwm.Slice = @enumFromInt(0);
+const backlight_ch = pwm.Pwm{ .slice_number = 0, .channel = .a };
+
+/// 1 kHz carrier: 125 MHz / clk_div / (period + 1). Too fast and the LED driver
+/// cannot follow it and stays dark.
+const clk_div = 2;
+const period = 62499;
+
+/// Full brightness is more light than the panel's contrast can hold back: blacks
+/// lift and the bright end of the range crowds together.
+pub const default_level: u8 = 220;
+
+/// Take GPIO16 from lcd.init, which brings it up as a plain output, and dim it.
+pub fn init() void {
+    set(default_level);
+}
+
+/// 0 is off, 255 is full brightness.
+///
+/// Configures the slice from scratch each time rather than only the compare
+/// value, because stopping a cart runs gpio.resetCartPWM, which disables all 12
+/// slices. Re-asserting the pin function matters for the same reason: driving
+/// GPIO16 as a plain output takes the pad back and leaves the slice writes inert.
+pub fn set(level: u8) void {
+    backlight_slice.set_clk_div(clk_div, 0);
+    backlight_slice.set_wrap(period);
+    // 255 overshoots the period so the output never goes low.
+    backlight_ch.set_level(@intCast((@as(u32, level) * (period + 1)) / 255));
+    backlight_slice.enable();
+    board.BKLT_PWM.set_function(.pwm);
+}

--- a/src/os/drivers/lcd.zig
+++ b/src/os/drivers/lcd.zig
@@ -7,6 +7,7 @@ const gpio = hal.gpio;
 const spi = hal.spi;
 const timer = @import("timer.zig");
 const dma = @import("dma.zig");
+const backlight = @import("backlight.zig");
 const board = microzig.board;
 const font = board.font;
 const terry = @import("../system/terry.zig");
@@ -264,6 +265,7 @@ const Command = enum(u8) {
     NORON = 0x13,
     INVOFF = 0x20,
     INVON = 0x21,
+    GAMSET = 0x26, // Gamma curve select
     DISPOFF = 0x28,
     DISPON = 0x29,
     CASET = 0x2A, // Column Address Set
@@ -443,7 +445,9 @@ fn initDisplay() void {
     writeCommandWithData(.PWCTR5, &.{ 0x8D, 0xEE }); // BCLK/2
 
     // VCOM control
-    writeCommandWithData(.VMCTR1, &.{0x1A}); // VCOM = -0.775V
+    // VCOMH = 3.900V. Measured on hardware: lower lifts the dark end, higher
+    // washes the blacks out.
+    writeCommandWithData(.VMCTR1, &.{0x38});
 
     // Memory access control with 90° clockwise rotation
     // MV (0x20) = Row/Column exchange, MX (0x40) = Column address order
@@ -467,6 +471,10 @@ fn initDisplay() void {
         0x27, 0x25, 0x2D, 0x3B,
         0x00, 0x01, 0x04, 0x13,
     });
+
+    // Gamma curve 1 (GC1, one-hot). The panel ignores the GMCTRP1/GMCTRN1 tables
+    // above but honours this, and curve 1 measured best of the four.
+    writeCommandWithData(.GAMSET, &.{0x02});
 
     // Normal display mode
     writeCommand(.NORON);
@@ -518,9 +526,9 @@ pub fn reinitDisplay() void {
 
 /// Display Control
 pub fn setBacklight(on: bool) void {
-    if (pins.bl) |bl| {
-        bl.put(if (on) 1 else 0);
-    }
+    // The pin belongs to a PWM slice once backlight.init has run, so a plain put
+    // on it would be ignored.
+    backlight.set(if (on) backlight.default_level else 0);
 }
 
 /// Prepare LCD for cart execution
@@ -895,7 +903,7 @@ pub fn createDT018BTFTPins() LCDPins {
             // RST: Reset (tied to hardware on v2, no GPIO control)
             .rst = null,
 
-            // BKLT_PWM: Backlight (connected to VBUS/5V, no GPIO control)
+            // BKLT_PWM: Backlight, dimmed by PWM in backlight.zig
             .bl = board.BKLT_PWM,
         },
         .spi = .{

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -424,11 +424,7 @@ fn hashCart(name: []const u8, size: u32) void {
 fn refreshCartDisplay() void {
     const z = terry.core0.fn_zone(@src()); defer z.end();
 
-    const backlight_enable_pin = board.BKLT_PWM;
-    backlight_enable_pin.set_function(.sio);
-    backlight_enable_pin.set_direction(.out);
-    backlight_enable_pin.put(1); // Ensure backlight is on for menu
-    lcd.setBacklight(true);
+    lcd.setBacklight(true); // Ensure backlight is on for menu
     lcd.fillScreen(lcd.BLACK);
 
     // Header

--- a/src/os/system/console.zig
+++ b/src/os/system/console.zig
@@ -157,7 +157,7 @@ const commands = [_]Command{
     .{ .name = "storage", .description = "Show storage filesystem statistics", .handler = cmdStorage },
     .{ .name = "wipe", .description = "Erase cart XIP flash and process RAM (wipe confirm)", .handler = cmdWipe },
     .{ .name = "menu", .description = "Return to cart selection screen", .handler = cmdMenu },
-    .{ .name = "reboot", .description = "Restart the system", .handler = cmdReboot },
+    .{ .name = "reboot", .description = "Restart the system (reboot [bootsel])", .handler = cmdReboot, .completion_provider = rebootCompletions },
 };
 
 // Unified Console Output (sends to USB CDC)
@@ -1062,7 +1062,15 @@ fn cmdWipe(iter: *std.mem.TokenIterator(u8, .scalar)) void {
 
 // Reboot Command
 fn cmdReboot(iter: *std.mem.TokenIterator(u8, .scalar)) void {
-    _ = iter;
+    if (iter.next()) |target| {
+        if (std.mem.eql(u8, target, "bootsel")) {
+            cmdRebootBootSel(iter);
+        } else {
+            printf("\r\nError: unknown reboot target '{s}'\r\n", .{target});
+        }
+        return;
+    }
+
     println("\r\nRebooting system...\r\n");
 
     // Small delay to allow message to be sent

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -11,6 +11,7 @@ const audio = @import("../drivers/audio.zig");
 const usb = @import("../drivers/usb.zig");
 const timer = @import("../drivers/timer.zig");
 const lcd = @import("../drivers/lcd.zig");
+const backlight = @import("../drivers/backlight.zig");
 const rom = @import("../drivers/rom.zig");
 const loader = @import("../loader/loader.zig");
 const debug_log = @import("../debug_log.zig");
@@ -198,6 +199,8 @@ pub fn init(config: InitConfig) !void {
             lcd.initWithAllPins(lcd_pins, lcd_cfg) catch |err| {
                 return err;
             };
+            // Dim the backlight, now that the LCD has brought its pin up
+            backlight.init();
         }
     }
 


### PR DESCRIPTION
HUMAN NOTE: this is written by claude and tested by me. It seems reasonable, and I tried to keep it as surgical/minimal as possible. I find that without this patch the display is way too washed out for the games I'm writing.

---

The V2 display looks washed out. A grayscale staircase shows why: level 2 of 31
already reads mid-grey, and everything above level 18 crowds so close to white
that the steps only separate when you view the panel off-axis. Dark cart art
suffers most, because it lands in the part of the range that lifts.

Two settings fix most of it, found by sweeping on hardware rather than by
calculation:

- `VMCTR1` (VCOMH) goes from `0x1A` to `0x38`, which is 3.900 V. Below that the
  dark end lifts; above it the blacks wash out again.
- `GAMSET` selects gamma curve 1, which measured best of the four.

The `GMCTRP1` and `GMCTRN1` gamma tables have no visible effect on this panel at
any values I tried, including Adafruit's stock ST7735R tables and several
hand-made curves. `GAMSET` does work, so the controller appears to implement only
part of the ST7735 gamma interface. I left both tables exactly as they were.

The backlight has never been dimmable: the kernel drove GPIO16 as a plain output
held high, which is more light than the panel's contrast ratio can hold back and
is also what makes the backlight bleed visible on a black screen. A new
`drivers/backlight.zig` puts the pin on PWM at 1 kHz and boots at 220 of 255.

One detail worth knowing if you touch this: GPIO16 is on **slice 0**, not the
slice 8 that `pin / 2` suggests. The GPIO mux repeats its PWM slots every
sixteen pins below GPIO32, so the mapping is `(pin >> 1) & 7`, and slices 8 to 11
are reachable only from GPIO32-47 on the B package. The `slice = pin / 2` comment
in `audio.zig` is not evidence against this, because the buzzer is on GPIO9 where
both formulas give slice 4. Getting it wrong is invisible from the register side:
slice 8 accepts its configuration and reports the requested duty while driving
nothing at all.

Two paths take the backlight away again, and both are handled:

- `refreshCartDisplay` forced GPIO16 high, which pulls the pad off the slice and
  left the brightness stuck at full after returning to the menu. It now asks for
  the configured level instead.
- `gpio.resetCartPWM` disables all twelve slices when a cart stops, so `set`
  configures the slice from scratch each call rather than writing only the
  compare value.

`PWCTR1` to `PWCTR5` are deliberately untouched. Gamma and VCOM only select among
voltages the panel already generates, whereas GVDD, VGH and VGL are the rails
that could damage it.

The change also wires up `reboot bootsel`. The handler and its tab completion
already existed, but `cmdReboot` discarded its argument, so the command reset
into the OS instead of the bootloader.

I tuned and tested this on a single board, and the right VCOM and gamma values
are panel-specific. If other boards look different under these settings, I am
happy to make them depend on `drivers/rev.zig`.