### PR TITLE
Add support for ram carts, load all carts as ram carts by default

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -514,10 +514,11 @@ pub fn add_os_cart(b: *Build, dep: *Build.Dependency, options: OsCartOptions) vo
         .name = options.name,
         .target = badge_v2_target,
         .optimize = options.optimize,
-        .root_source_file = dep.builder.path("src/os/cart/cart_entry.zig"),
+        .root_source_file = dep.builder.path("src/os/cart/cart_ram_entry.zig"),
         .linker_script = .{
-            .file = dep.builder.path("src/cart/cart_xip.ld"),
+            .file = dep.builder.path("src/cart/cart_ram.ld"),
             .generate = .none,
+            .assert_microzig_main = false,
         },
     });
 

--- a/src/cart/cart_ram.ld
+++ b/src/cart/cart_ram.ld
@@ -1,0 +1,105 @@
+/*
+ * Cart RAM Linker Script
+ * 
+ * Linker script is for building cart programs that run on Core 1
+ * of the SYCL Badge OS. Carts built with this script are loaded into
+ * and executed from RAM.
+ *
+ * Memory Map:
+ *   Cart RAM:         0x20035100 - 0x20080000 (307KB process_ram)
+ *
+ * Usage:
+ *   When building carts, use this linker script to ensure the cart
+ *   is linked for the correct execution address.
+ *
+ * Requirements:
+ *   - Cart binary must be <= 256KB
+ *   - Entry point must be at vector table offset 4 (Reset_Handler)
+ *   - Cart should use process_ram for all RAM needs
+ */
+
+ENTRY(_start)
+
+MEMORY
+{
+    RAM(rwx) : ORIGIN = 0x20035100, LENGTH = 0x4AF00
+}
+
+SECTIONS
+{
+    /* MicroZig vector table - MUST be at the VERY start of flash (offset 0) */
+    /* MicroZig exports this in "microzig_flash_start" section */
+    /* ARM Cortex-M: [0] = initial SP, [1] = Reset_Handler */
+    .cart_descriptor :
+    {
+        KEEP(*(.cart_descriptor))
+    } > RAM
+
+    /* Code and read-only data */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > RAM
+
+    /* ARM exception unwind tables */
+    .ARM.extab : { *(.ARM.extab*) } > RAM
+    .ARM.exidx :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > RAM
+
+    /* Initialized data: stored in flash, copied to RAM at startup */
+    .data :
+    {
+        . = ALIGN(4);
+        __data_start__ = .;
+        *(.data*)
+        . = ALIGN(4);
+        __data_end__ = .;
+    } > RAM
+
+    /* Zero-initialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    .heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __heap_start__ = .;
+        /* Heap grows upward toward stack */
+    } > RAM
+
+    /* Stack at end of RAM, grows downward */
+    /* Reserve 32KB for stack to reduce overflow risk in complex carts. */
+    __stack_size__ = 32K;
+    __stack_top__ = ORIGIN(RAM) + LENGTH(RAM);
+    __stack_limit__ = __stack_top__ - __stack_size__;
+
+    /* Sanity checks */
+    ASSERT(__bss_end__ <= __stack_limit__, "ERROR: BSS overflows into stack region")
+    ASSERT((__stack_top__ & 0x7) == 0, "ERROR: Stack not 8-byte aligned")
+}
+
+/* Export symbols for cart startup code */
+__ram_start__ = ORIGIN(RAM);
+__ram_end__ = ORIGIN(RAM) + LENGTH(RAM);
+
+/* Export symbols to stub out microzig boot, OS does this init */
+microzig_bss_start = __ram_end__;
+microzig_bss_end = __ram_end__;
+microzig_data_start = __ram_end__;
+microzig_data_end = __ram_end__;
+microzig_data_load_start = __ram_end__;

--- a/src/os/cart.zig
+++ b/src/os/cart.zig
@@ -8,6 +8,7 @@ const mailbox = @import("ipc/mailbox.zig");
 const loader = @import("loader/loader.zig");
 const storage = @import("loader/storage.zig");
 const shared_mem = @import("ipc/shared_mem.zig");
+const cd = @import("cart/cart_descriptor.zig");
 
 // Use panic handler from system
 pub const panic = @import("system/panic.zig").panic;
@@ -15,6 +16,8 @@ pub const panic = @import("system/panic.zig").panic;
 /// Linker symbols for cart_xip region
 extern const __cart_xip_start__: u8;
 extern const __cart_xip_end__: u8;
+extern const __process_ram_start__: u8;
+extern const __process_ram_end__: u8;
 
 /// Get cart_xip base address
 fn getCartXipStart() u32 {
@@ -23,6 +26,14 @@ fn getCartXipStart() u32 {
 
 fn getCartXipEnd() u32 {
     return @intFromPtr(&__cart_xip_end__);
+}
+
+fn getCartRamStart() u32 {
+    return @intFromPtr(&__process_ram_start__);
+}
+
+fn getCartRamEnd() u32 {
+    return @intFromPtr(&__process_ram_end__);
 }
 
 fn clearCore1InterruptAndFaultState() void {
@@ -125,8 +136,8 @@ fn handleMessage(msg: mailbox.Message) void {
     switch (msg_type) {
         mailbox.MessageType.CART_EXECUTE => {
             // Execute cart at the given entry point offset
-            const entry_offset = mailbox.MessageType.getEntryPointOffset(msg);
-            executeCart(entry_offset);
+            const exec: mailbox.MessageType.CartExecute = @bitCast(msg);
+            executeCart(exec);
         },
         mailbox.MessageType.CART_LOAD => {
             // Legacy cart load (deprecated)
@@ -155,55 +166,106 @@ fn handleMessage(msg: mailbox.Message) void {
 /// cores creates a data race that can make the kernel see the state flicker,
 /// causing it to treat the cart as stopped and restart the menu while the
 /// cart is still running.
-fn executeCart(vector_table_offset: u24) void {
-    const cart_xip_start = getCartXipStart();
-    const cart_xip_end = getCartXipEnd();
-    const vector_table_addr = cart_xip_start + vector_table_offset;
-
+fn executeCart(exec: mailbox.MessageType.CartExecute) void {
     mailbox.send(mailbox.MessageType.CART_RUNNING);
 
-    const vector_table: *const [2]u32 = @ptrFromInt(vector_table_addr);
-    const initial_sp = vector_table[0];
-    const entry_point = vector_table[1];
+    const cart_xip_start = getCartXipStart();
+    const cart_xip_end = getCartXipEnd();
+    const cart_ram_start = getCartRamStart();
+    const cart_ram_end = getCartRamEnd();
+    if (exec.xip) {
+        const vector_table_addr = cart_xip_start + exec.offset;
 
-    // Validate SP/PC from cart vector table before taking over Core 1.
-    // Bad values here often show up later as UsageFault INVSTATE on first
-    // exception entry/return.
-    if ((initial_sp & 0x7) != 0) {
-        mailbox.send(mailbox.MessageType.CART_CRASHED);
-        return;
+        const vector_table: *const [2]u32 = @ptrFromInt(vector_table_addr);
+        const initial_sp = vector_table[0];
+        const entry_point = vector_table[1];
+
+        // Validate SP/PC from cart vector table before taking over Core 1.
+        // Bad values here often show up later as UsageFault INVSTATE on first
+        // exception entry/return.
+        if ((initial_sp & 0x7) != 0) {
+            mailbox.send(mailbox.MessageType.CART_CRASHED);
+            return;
+        }
+        if (initial_sp < 0x2002A100 or initial_sp > 0x20080000) {
+            mailbox.send(mailbox.MessageType.CART_CRASHED);
+            return;
+        }
+        if ((entry_point & 0x1) == 0) {
+            mailbox.send(mailbox.MessageType.CART_CRASHED);
+            return;
+        }
+        const entry_even = entry_point & 0xFFFF_FFFE;
+        if (entry_even < cart_xip_start or entry_even >= cart_xip_end) {
+            mailbox.send(mailbox.MessageType.CART_CRASHED);
+            return;
+        }
+
+        clearCore1InterruptAndFaultState();
+
+        // Point Core 1's VTOR at the cart's vector table so that any exceptions
+        // (HardFault, etc.) use the cart's handlers instead of the OS kernel's.
+        const VTOR: *volatile u32 = @ptrFromInt(0xE000ED08);
+        VTOR.* = vector_table_addr;
+
+        asm volatile ("dsb");
+        asm volatile ("isb");
+
+        // One-way jump — the cart takes over Core 1.  jumpToCart never returns.
+        jumpToCart(initial_sp, entry_point);
+    } else {
+        const header: [*]u32 = @ptrFromInt(cart_ram_start + exec.offset);
+        if (header[0] != cd.CART_MAGIC) {
+            mailbox.send(mailbox.MessageType.CART_CRASHED);
+            return;
+        }
+        const initial_stack = cart_ram_end;
+        var entry_point: u32 = 0;
+        switch (header[1]) {
+            cd.CART_VERSION_V1 => {
+                const descriptor: *const cd.CartDescriptorTable_v1 = @ptrCast(header);
+                // BSS has been cleared already by the loader
+                entry_point = @intFromPtr(descriptor.entry_point);
+            },
+            else => {
+                mailbox.send(mailbox.MessageType.CART_CRASHED);
+                return;
+            },
+        }
+
+        clearCore1InterruptAndFaultState();
+
+        microzig.interrupt.disable_interrupts();
+
+        // Point Core 1's VTOR at the cart's vector table so that any exceptions
+        // (HardFault, etc.) use the cart's handlers instead of the OS kernel's.
+        // TODO set VTOR to some sort of OS fault handler vector table
+        //const VTOR: *volatile u32 = @ptrFromInt(0xE000ED08);
+        //VTOR.* = vector_table_addr;
+
+        // CPACR — Coprocessor Access Control Register (0xE000ED88)
+        // Bits [23:20] = CP11:CP10 access. 0b11 each = full access.
+        const CPACR: *volatile u32 = @ptrFromInt(0xE000ED88);
+        // FPCCR — Floating-Point Context Control Register (0xE000EF34)
+        const FPCCR: *volatile u32 = @ptrFromInt(0xE000EF34);
+
+        // Enable lazy FP state preservation (bits 31:30 = ASPEN:LSPEN).
+        FPCCR.* = FPCCR.* | (1 << 31) | (1 << 30);
+
+        // Grant full access to CP10 and CP11 (the FPU).
+        CPACR.* = CPACR.* | (0xF << 20);
+
+        // Barriers so subsequent instructions see the new FPU/VTOR state.
+        asm volatile ("dsb");
+        asm volatile ("isb");
+
+        jumpToCart(initial_stack, entry_point);
     }
-    if (initial_sp < 0x2002A100 or initial_sp > 0x20080000) {
-        mailbox.send(mailbox.MessageType.CART_CRASHED);
-        return;
-    }
-    if ((entry_point & 0x1) == 0) {
-        mailbox.send(mailbox.MessageType.CART_CRASHED);
-        return;
-    }
-    const entry_even = entry_point & 0xFFFF_FFFE;
-    if (entry_even < cart_xip_start or entry_even >= cart_xip_end) {
-        mailbox.send(mailbox.MessageType.CART_CRASHED);
-        return;
-    }
-
-    clearCore1InterruptAndFaultState();
-
-    // Point Core 1's VTOR at the cart's vector table so that any exceptions
-    // (HardFault, etc.) use the cart's handlers instead of the OS kernel's.
-    const VTOR: *volatile u32 = @ptrFromInt(0xE000ED08);
-    VTOR.* = vector_table_addr;
-
-    asm volatile ("dsb");
-    asm volatile ("isb");
-
-    // One-way jump — the cart takes over Core 1.  jumpToCart never returns.
-    jumpToCart(initial_sp, entry_point);
 }
 
 /// Jump to cart code with new stack pointer
 /// This function does not return - it transfers control to the cart
-fn jumpToCart(stack_pointer: u32, entry_point: u32) void {
+fn jumpToCart(stack_pointer: u32, entry_point: u32) noreturn {
     // Set up the stack pointer and jump to the entry point
     // Using inline assembly for ARM Cortex-M
     asm volatile (

--- a/src/os/cart.zig
+++ b/src/os/cart.zig
@@ -253,7 +253,7 @@ fn executeCart(exec: mailbox.MessageType.CartExecute) void {
         FPCCR.* = FPCCR.* | (1 << 31) | (1 << 30);
 
         // Grant full access to CP10 and CP11 (the FPU).
-        CPACR.* = CPACR.* | (0xF << 20);
+        CPACR.* = 0xFFFF_FFFF;
 
         // Barriers so subsequent instructions see the new FPU/VTOR state.
         asm volatile ("dsb");

--- a/src/os/cart/cart_descriptor.zig
+++ b/src/os/cart/cart_descriptor.zig
@@ -1,0 +1,19 @@
+// Carts begin with a Cart Descriptor Table, which tells the OS about
+// the cart contents. All descriptor tables of all versions begin with
+// CART_MAGIC, followed by the version number. This allows the OS to
+// ensure that it is reading a valid version table before jumping to
+// its entry point. The OS maintains limited backwards compatibility
+// for older versions, which are maintained in this file.
+pub const CART_MAGIC = 0x54C1_CA41;
+
+pub const CART_VERSION_V1: u32 = 0x54C126_01;
+pub const CartDescriptorTable_v1 = extern struct {
+    magic: u32 = CART_MAGIC,
+    version: u32 = CART_VERSION_V1,
+    bss_start: *u8,
+    bss_end: *u8,
+    entry_point: *const fn() callconv(.c) void,
+};
+
+pub const CART_VERSION_CURRENT = CART_VERSION_V1;
+pub const CartDescriptorTable = CartDescriptorTable_v1;

--- a/src/os/cart/cart_ram_entry.zig
+++ b/src/os/cart/cart_ram_entry.zig
@@ -1,0 +1,62 @@
+//! OS Cart Entry Wrapper
+//!
+//! Bridges the old badge-v1 cart ABI (export fn start / export fn update)
+//! into a single main() loop expected by MicroZig's startup.
+//!
+//! The build system injects the cart's source as "user_cart". Because the cart
+//! uses `export fn start/update` (not `pub`), we declare them as extern symbols
+//! and let the linker resolve them from the same binary.
+const builtin = @import("builtin");
+const cart_api = @import("cart-api");
+const cd = @import("cart_descriptor.zig");
+
+// Variables exported by the linker script
+extern var __bss_start__: u8;
+extern var __bss_end__: u8;
+
+export const cart_descriptor: cd.CartDescriptorTable linksection(".cart_descriptor") = .{
+    .bss_start = &__bss_start__,
+    .bss_end = &__bss_end__,
+    .entry_point = &_start,
+};
+
+// Pull in the user cart module so its exported symbols are linked.
+const user_cart = @import("user_cart");
+comptime {
+    _ = user_cart;
+}
+
+// ─── Panic Handler ────────────────────────────────────────────────────────────
+// If the user cart defines `pub fn panic`, wire it up as the root-module panic
+// so Zig uses it instead of microzig.panic (which calls @breakpoint() → HardFault).
+// If not, fall back to a default that sends the message via cart.trace() and halts
+// with WFE so Core 0 has time to print it before the system freezes.
+
+fn default_panic(msg: []const u8, _: ?*@import("std").builtin.StackTrace, _: ?usize) noreturn {
+    cart_api.trace(msg);
+    while (true) {
+        switch (comptime builtin.cpu.arch) {
+            .wasm32, .wasm64 => {},
+            else => asm volatile ("wfe"),
+        }
+    }
+}
+
+pub const panic = if (@hasDecl(user_cart, "panic"))
+    user_cart.panic
+else
+    default_panic;
+
+/// These are provided by the user cart as `export fn start()`/`export fn update()`.
+extern fn start() void;
+extern fn update() void;
+
+export fn _start() callconv(.c) void {
+    start();
+    while (true) {
+        update();
+        // Signal Core 0 that this frame is complete and wait for the
+        // LCD flush to finish before starting the next frame.
+        cart_api.present();
+    }
+}

--- a/src/os/ipc/mailbox.zig
+++ b/src/os/ipc/mailbox.zig
@@ -83,6 +83,22 @@ pub const MessageType = struct {
     // CART_EXECUTE: payload contains entry point address (lower 24 bits)
     // For full 32-bit entry point, use shared memory
     pub const CART_EXECUTE: u8 = 0x20; // Execute cart at entry point
+    pub const CartExecute = packed struct (u32) {
+        /// Offset of the vector table or cart descriptor.
+        /// If XIP is true, this is the offset from cart_xip_start
+        /// to the vector table.
+        /// If XIP is false, this is the offset from cart_ram_start
+        /// to the cart descriptor
+        offset: u23,
+        /// If true, the cart is an XIP flash cart and contains a
+        /// vector table with the start address.
+        /// If false, the cart is a RAM cart with a cart descriptor
+        /// which can be used to initialize it.
+        xip: bool,
+        /// Message type for sending this value through the mailbox
+        msg: u8 = CART_EXECUTE,
+    };
+
     pub const CART_RUNNING: Message = 0x20000001; // Core 1 confirms cart is running
     pub const CART_FINISHED: Message = 0x20000002; // Cart execution completed
     pub const CART_CRASHED: Message = 0x20000003; // Cart crashed/faulted
@@ -139,22 +155,5 @@ pub const MessageType = struct {
     /// Extract payload from a message
     pub fn getPayload(msg: Message) u24 {
         return @truncate(msg);
-    }
-
-    /// Create a CART_EXECUTE message with entry point offset
-    /// The offset is relative to cart_xip_start (0x101C0000)
-    /// This allows 24-bit payload to address full 256KB cart region
-    pub fn cartExecute(entry_point_offset: u24) Message {
-        return withPayload(CART_EXECUTE, entry_point_offset);
-    }
-
-    /// Check if a message is a CART_EXECUTE message
-    pub fn isCartExecute(msg: Message) bool {
-        return getType(msg) == CART_EXECUTE;
-    }
-
-    /// Get entry point offset from CART_EXECUTE message
-    pub fn getEntryPointOffset(msg: Message) u24 {
-        return getPayload(msg);
     }
 };

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -563,6 +563,7 @@ fn runSelectedCart() void {
             loader.LoadError.InvalidUF2 => "Invalid UF2",
             loader.LoadError.UnsupportedFamily => "Wrong chip",
             loader.LoadError.AddressMismatch => "Wrong address",
+            loader.LoadError.VersionMismatch => "Bad Cart Version",
             loader.LoadError.FlashWriteError => "Flash error",
             loader.LoadError.ReadError => "Read error",
         };
@@ -573,7 +574,7 @@ fn runSelectedCart() void {
     };
 
     // Prepare LCD for cart: ensure normal mode (not inverted) and clear screen
-    console.printf("[BTN] cart loaded, entry_point=0x{x}\r\n", .{entry_point});
+    console.printf("[BTN] cart loaded, entry_point={any}\r\n", .{entry_point});
     // NOTE: do NOT touch the LCD here - prepareForCart/fillScreen before executeCart
     // interferes with the cart's own LCD init (forces MADCTL, may leave DMA running).
     // The console 'cart run' command works precisely because it skips these LCD calls.

--- a/src/os/linker.ld
+++ b/src/os/linker.ld
@@ -217,10 +217,8 @@ SECTIONS
   .process_ram (NOLOAD) :
   {
     . = ALIGN(8);
-    __process_ram_start__ = .;
     *(.process_ram*)
     . = ALIGN(8);
-    __process_ram_end__ = .;
   } > process_ram
 
   /* compile-time symbol describing the maximum heap limit (start of shared_mem) */

--- a/src/os/loader/loader.zig
+++ b/src/os/loader/loader.zig
@@ -8,11 +8,16 @@ const rom = @import("../drivers/rom.zig");
 const interrupt = microzig.interrupt;
 const terry = @import("../system/terry.zig");
 const multicore = @import("../system/multicore.zig");
-const log = std.log.scoped(.loader);
+const log_scope = .loader;
+const log = std.log.scoped(log_scope);
+const cd = @import("../cart/cart_descriptor.zig");
+const mailbox = @import("../ipc/mailbox.zig");
 
 /// Linker symbols for cart_xip region
 extern const __cart_xip_start__: u8;
 extern const __cart_xip_end__: u8;
+extern const __process_ram_start__: u8;
+extern const __process_ram_end__: u8;
 
 /// XIP base address for flash
 const XIP_BASE: u32 = 0x10000000;
@@ -43,6 +48,7 @@ pub const LoadError = error{
     InvalidUF2,
     UnsupportedFamily,
     AddressMismatch,
+    VersionMismatch,
     FlashWriteError,
     ReadError,
 };
@@ -50,8 +56,8 @@ pub const LoadError = error{
 /// Current cart state
 var cart_state: terry.core0.TrackedStateMachine(CartState) = undefined;
 
-/// Loaded cart entry point (Reset_Handler address from vector table)
-var cart_entry_point: u32 = 0;
+/// Loaded cart entry point
+var cart_entry_point: mailbox.MessageType.CartExecute = undefined;
 
 /// Loaded cart info
 var loaded_cart_name: [11:0]u8 = undefined;
@@ -59,10 +65,6 @@ var loaded_cart_size: u32 = 0;
 
 /// Buffer for accumulating flash write data (one erase block)
 var flash_write_buffer: [FLASH_ERASE_BLOCK]u8 align(4) linksection(".process_ram") = undefined;
-
-/// Buffer for reading entire UF2 file from storage
-/// 320KB should be enough for most carts (max cart binary is 256KB, UF2 overhead ~2x)
-var cart_buffer: [320 * 1024]u8 align(4) linksection(".process_ram") = undefined;
 
 /// Get cart_xip region start address
 pub fn getCartXipStart() u32 {
@@ -77,6 +79,18 @@ pub fn getCartXipEnd() u32 {
 /// Get cart_xip region size
 pub fn getCartXipSize() u32 {
     return getCartXipEnd() - getCartXipStart();
+}
+
+pub fn getCartRamStart() u32 {
+    return @intFromPtr(&__process_ram_start__);
+}
+
+pub fn getCartRamEnd() u32 {
+    return @intFromPtr(&__process_ram_end__);
+}
+
+pub fn getCartRamSize() u32 {
+    return getCartRamEnd() - getCartRamStart();
 }
 
 pub const CartVector = struct {
@@ -101,8 +115,8 @@ pub fn getCartXipVector() ?CartVector {
 /// (Core 1 will read SP and entry point from this address)
 fn findVectorTableAddr(start_addr: u32, end_addr: u32) ?u32 {
     // RAM range for valid stack pointer
-    const RAM_START: u32 = 0x20000000;
-    const RAM_END: u32 = 0x20080000;
+    const RAM_START: u32 = getCartRamStart();
+    const RAM_END: u32 = getCartRamEnd();
 
     // Cart XIP range for valid entry point
     const xip_start = getCartXipStart();
@@ -143,7 +157,7 @@ pub fn getState() CartState {
 }
 
 /// Get loaded cart entry point
-pub fn getEntryPoint() u32 {
+pub fn getEntryPoint() mailbox.MessageType.CartExecute {
     return cart_entry_point;
 }
 
@@ -167,7 +181,7 @@ pub fn markRunning() void {
 /// Stop the current cart
 pub fn stop() void {
     cart_state.set_state(.none, @src());
-    cart_entry_point = 0;
+    cart_entry_point = undefined;
 }
 
 /// Auto-start cart if only one is present in storage
@@ -210,7 +224,7 @@ pub fn eraseCartRegion() LoadError!void {
 
 /// Load a UF2 cart from FAT12 storage and program it to cart_xip flash
 /// Returns the entry point address on success
-pub fn loadUF2Cart(name: []const u8) LoadError!u32 {
+pub fn loadUF2Cart(name: []const u8) LoadError!mailbox.MessageType.CartExecute {
     // If a cart is already running, stop Core 1 before erasing cart_xip.
     if (cart_state.state == .running) {
         multicore.haltCore1();
@@ -227,92 +241,85 @@ pub fn loadUF2Cart(name: []const u8) LoadError!u32 {
 
     // Validate size (UF2 blocks are 512 bytes each, cart_xip is 256KB)
     // Max useful data per block is 256 bytes, so max UF2 file size is roughly 2x cart_xip size
-    const max_uf2_size = @min(getCartXipSize() * 2, @as(u32, @intCast(cart_buffer.len)));
+    const max_uf2_size = (getCartXipSize() + getCartRamSize()) * 2;
     if (cart_info.size > max_uf2_size) {
         return LoadError.FileTooLarge;
     }
 
     // Read and parse UF2 blocks
-    const entry_point = try loadUF2FromStorage(cart_info);
+    const start_info = try loadUF2FromStorage(cart_info);
 
     // Save cart info
     @memcpy(&loaded_cart_name, &cart_info.short_name);
     loaded_cart_size = cart_info.size;
-    cart_entry_point = entry_point;
+    cart_entry_point = start_info;
     cart_state.set_state(.ready, @src());
-    return entry_point;
+    return start_info;
 }
 
 /// Internal function to load UF2 from storage and program to flash
-fn loadUF2FromStorage(cart_info: storage.CartInfo) LoadError!u32 {
+fn loadUF2FromStorage(cart_info: storage.CartInfo) LoadError!mailbox.MessageType.CartExecute {
     const cart_xip_start = getCartXipStart();
     const cart_xip_end = getCartXipEnd();
     const cart_xip_size = getCartXipSize();
+    const cart_ram_start = getCartRamStart();
+    const cart_ram_end = getCartRamEnd();
 
     log.info("cart info: {f}", .{cart_info});
     log.info("cart_xip_start: 0x{X}", .{cart_xip_start});
     log.info("cart_xip_end: 0x{X}", .{cart_xip_end});
     log.info("cart_xip_size: 0x{X}", .{cart_xip_size});
 
-    // Read the entire UF2 file into the cart buffer first
-    const bytes_read = storage.readCart(cart_info, &cart_buffer);
-    if (bytes_read == 0 or bytes_read != cart_info.size) {
-        return LoadError.ReadError;
-    }
-
-    log.info("read cart return: {}", .{bytes_read});
-    if (bytes_read % uf2.BLOCK_SIZE != 0) {
-        log.err("block size is incorrect: bytes_read={} block_size={}", .{ bytes_read, uf2.BLOCK_SIZE });
+    if (cart_info.size % uf2.BLOCK_SIZE != 0) {
         return LoadError.InvalidUF2;
     }
 
-    // Calculate number of UF2 blocks
-    const num_blocks = bytes_read / uf2.BLOCK_SIZE;
-    if (num_blocks == 0) {
-        log.err("zero UF2 blocks", .{});
-        return LoadError.InvalidUF2;
-    }
+    var file: storage.FileIterator = .init(cart_info.size, cart_info.start_cluster);
 
-    log.debug("UF2 read: bytes={d} blocks={d}", .{ bytes_read, num_blocks });
-
-    // Erase the cart_xip region
-    try eraseCartXipRegion();
     var parser = uf2.Parser{};
-    var block_index: u32 = 0;
 
     // Track which parts of cart_xip we need to write
-    var min_offset: u32 = cart_xip_size;
-    var max_offset: u32 = 0;
+    var min_xip_offset: u32 = cart_xip_size;
 
     // Temporary buffer to accumulate binary data before flash write
     // We'll write in 4KB blocks
     var current_erase_block: u32 = 0xFFFFFFFF;
     var buffer_dirty: bool = false;
 
-    // Process each UF2 block from the buffer
-    while (block_index < num_blocks) {
-        const block_offset = block_index * uf2.BLOCK_SIZE;
-        const block_data = cart_buffer[block_offset..][0..uf2.BLOCK_SIZE];
+    var has_xip_blocks: bool = false;
+    var has_ram_blocks: bool = false;
 
-        for (0..512 / 8) |row| {
-            const row_data = block_data[8 * row ..];
-            const addr: u32 = @intFromPtr(&cart_buffer) + block_offset + (8 * row);
-            log.debug("0x{X}: {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2}", .{
-                addr,
-                row_data[0],
-                row_data[1],
-                row_data[2],
-                row_data[3],
-                row_data[4],
-                row_data[5],
-                row_data[6],
-                row_data[7],
-            });
+    var ram_cart_descriptor: ?[*]u32 = null;
+
+    // Process each UF2 block from the buffer
+    var block_index: u32 = 0;
+    var file_pos: usize = 0;
+    while (file.next()) |block_data| : (block_index += 1) {
+        if (block_data.len != uf2.BLOCK_SIZE) {
+            return LoadError.ReadError;
+        }
+
+        if (std.log.logEnabled(.debug, log_scope)) {
+            for (0..512 / 8) |row| {
+                const row_data = block_data[8 * row ..];
+                log.debug("0x{X}: {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2} {X:0>2}", .{
+                    file_pos,
+                    row_data[0],
+                    row_data[1],
+                    row_data[2],
+                    row_data[3],
+                    row_data[4],
+                    row_data[5],
+                    row_data[6],
+                    row_data[7],
+                });
+                file_pos += 8;
+            }
         }
 
         // Parse the block
-        const block = parser.parseBlock(block_data) catch {
-            log.err("Failed to parse block block_index={} num_blocks={}", .{ block_index, num_blocks });
+        const block = parser.parseBlock(block_data[0..uf2.BLOCK_SIZE]) catch {
+            log.err("Failed to parse block block_index={} num_blocks={}", .{ block_index, parser.expected_blocks });
             return LoadError.InvalidUF2;
         };
 
@@ -322,78 +329,107 @@ fn loadUF2FromStorage(cart_info: storage.CartInfo) LoadError!u32 {
             if (block.hasFamilyId() and !block.isRP235X()) {
                 return LoadError.UnsupportedFamily;
             }
-
-            // Check block count matches file length
-            if (block.header.num_blocks != num_blocks) {
-                log.err("block count does not match file length: block.header.num_blocks={} num_blocks={}", .{ block.header.num_blocks, num_blocks });
-                return LoadError.InvalidUF2;
-            }
-
-            // Check base address is within cart_xip
-            if (block.header.target_addr < cart_xip_start or
-                block.header.target_addr >= cart_xip_end)
-            {
-                return LoadError.AddressMismatch;
-            }
         }
 
-        // Calculate offset within cart_xip
-        const target_offset = block.header.target_addr - cart_xip_start;
         const payload = block.getPayload();
         if (payload.len == 0) {
             log.err("calculate offset within cart_xip", .{});
             return LoadError.InvalidUF2;
         }
 
-        // Validate each block address range
-        if (block.header.target_addr < cart_xip_start or
-            block.header.target_addr + @as(u32, @intCast(payload.len)) > cart_xip_end)
+        // Check base address is within cart_xip
+        if (block.header.target_addr >= cart_xip_start and
+            block.header.target_addr + payload.len < cart_xip_end)
+        {
+            if (has_ram_blocks) {
+                // For now, we can't support uf2 files with both ram and flash data in them.
+                // The flash write buffer is mapped into process RAM, so it will overlap
+                // with the ram blocks and potentially clobber loaded cart memory.
+                return LoadError.AddressMismatch;
+            }
+
+            // When we encounter the first xip block, erase the whole flash region
+            if (!has_xip_blocks) {
+                // Erase the cart_xip region
+                try eraseCartXipRegion();
+            }
+
+            has_xip_blocks = true;
+
+            const target_offset = block.header.target_addr - cart_xip_start;
+            min_xip_offset = @min(min_xip_offset, target_offset);
+
+            // Determine which erase block this belongs to
+            const erase_block_num = target_offset / FLASH_ERASE_BLOCK;
+            const offset_in_block = target_offset % FLASH_ERASE_BLOCK;
+
+            // If switching to a new erase block, flush the old one
+            if (erase_block_num != current_erase_block) {
+                if (buffer_dirty) {
+                    try flushWriteBuffer(current_erase_block, cart_xip_start);
+                }
+                // Initialize new buffer with 0xFF (erased flash state)
+                @memset(&flash_write_buffer, 0xFF);
+                current_erase_block = erase_block_num;
+                buffer_dirty = false;
+            }
+
+            // Copy payload to write buffer
+            const copy_len = @min(payload.len, FLASH_ERASE_BLOCK - offset_in_block);
+            @memcpy(flash_write_buffer[offset_in_block .. offset_in_block + copy_len], payload[0..copy_len]);
+            buffer_dirty = true;
+
+            // Handle payload spanning multiple erase blocks (rare but possible)
+            if (copy_len < payload.len) {
+                // Flush current block
+                try flushWriteBuffer(current_erase_block, cart_xip_start);
+
+                // Move to next block
+                current_erase_block += 1;
+                @memset(&flash_write_buffer, 0xFF);
+
+                // Copy remaining payload
+                const remaining = payload.len - copy_len;
+                @memcpy(flash_write_buffer[0..remaining], payload[copy_len..]);
+                buffer_dirty = true;
+            }
+        }
+        else if (block.header.target_addr >= cart_ram_start and
+                 block.header.target_addr + payload.len <= cart_ram_end)
+        {
+            // If this RAM block was preceded by flash blocks, there is unwritten
+            // flash data in the cart's memory space. The cart memory might overwrite
+            // that flash data, so we need to flush it first. Once has_ram_blocks is
+            // set, we don't allow any more flash blocks, so the cart memory won't
+            // be overwritten again.
+            if (buffer_dirty) {
+                try flushWriteBuffer(current_erase_block, cart_xip_start);
+                buffer_dirty = false;
+                asm volatile ("" ::: .{ .memory = true });
+            }
+
+            has_ram_blocks = true;
+
+            if (ram_cart_descriptor == null) {
+                // See if we can find the cart descriptor
+                const data_as_u32 = std.mem.bytesAsSlice(u32, payload[0..std.mem.alignBackward(usize, payload.len, @alignOf(u32))]);
+                if (std.mem.indexOfScalar(u32, data_as_u32, cd.CART_MAGIC)) |index| {
+                    const byte_offset = index * @sizeOf(u32);
+                    ram_cart_descriptor = @ptrFromInt(block.header.target_addr + byte_offset);
+                }
+            }
+
+            const ptr: [*]u8 = @ptrFromInt(block.header.target_addr);
+            @memcpy(ptr, payload);
+        }
+        else
         {
             return LoadError.AddressMismatch;
         }
+    }
 
-        // Track extent
-        if (target_offset < min_offset) min_offset = target_offset;
-        if (target_offset + @as(u32, @intCast(payload.len)) > max_offset) {
-            max_offset = target_offset + @as(u32, @intCast(payload.len));
-        }
-
-        // Determine which erase block this belongs to
-        const erase_block_num = target_offset / FLASH_ERASE_BLOCK;
-        const offset_in_block = target_offset % FLASH_ERASE_BLOCK;
-
-        // If switching to a new erase block, flush the old one
-        if (erase_block_num != current_erase_block) {
-            if (buffer_dirty) {
-                try flushWriteBuffer(current_erase_block, cart_xip_start);
-            }
-            // Initialize new buffer with 0xFF (erased flash state)
-            @memset(&flash_write_buffer, 0xFF);
-            current_erase_block = erase_block_num;
-            buffer_dirty = false;
-        }
-
-        // Copy payload to write buffer
-        const copy_len = @min(payload.len, FLASH_ERASE_BLOCK - offset_in_block);
-        @memcpy(flash_write_buffer[offset_in_block .. offset_in_block + copy_len], payload[0..copy_len]);
-        buffer_dirty = true;
-
-        // Handle payload spanning multiple erase blocks (rare but possible)
-        if (copy_len < payload.len) {
-            // Flush current block
-            try flushWriteBuffer(current_erase_block, cart_xip_start);
-
-            // Move to next block
-            current_erase_block += 1;
-            @memset(&flash_write_buffer, 0xFF);
-
-            // Copy remaining payload
-            const remaining = payload.len - copy_len;
-            @memcpy(flash_write_buffer[0..remaining], payload[copy_len..]);
-            buffer_dirty = true;
-        }
-
-        block_index += 1;
+    if (block_index == 0) {
+        return LoadError.InvalidUF2;
     }
 
     // Flush any remaining data
@@ -401,18 +437,51 @@ fn loadUF2FromStorage(cart_info: storage.CartInfo) LoadError!u32 {
         try flushWriteBuffer(current_erase_block, cart_xip_start);
     }
 
-    // Find the vector table by scanning for valid SP and entry point pattern
-    // Some toolchains add padding before the vector table
-    // Returns the vector table ADDRESS (not entry point) so Core 1 can read both SP and entry
     if (!parser.isComplete()) {
         log.err("parser is not complete", .{});
         return LoadError.InvalidUF2;
     }
-    parser.validateAddressRange(cart_xip_start, cart_xip_end) catch {
-        return LoadError.AddressMismatch;
-    };
 
-    const vector_table_addr = findVectorTableAddr(cart_xip_start + min_offset, cart_xip_end) orelse {
+    // Check if it's a ram cart first
+    if (ram_cart_descriptor) |cart_descriptor| {
+        // Verify the version
+        switch (cart_descriptor[1]) {
+            cd.CART_VERSION_V1 => {
+                const descriptor: *cd.CartDescriptorTable_v1 = @ptrCast(cart_descriptor);
+                const bss_start = @intFromPtr(descriptor.bss_start);
+                const bss_end = @intFromPtr(descriptor.bss_end);
+                const entry_point = @intFromPtr(descriptor.entry_point);
+                // Verify the pointers
+                if (bss_start < cart_ram_start or bss_start > cart_ram_end or
+                    bss_end < cart_ram_start or bss_end > cart_ram_end or
+                    bss_start > bss_end or
+                    !(entry_point >= cart_ram_start and entry_point < cart_ram_end or
+                        entry_point >= cart_xip_start and entry_point < cart_xip_end) or
+                        entry_point & 1 == 0) // entry_point must be thumb
+                {
+                    return LoadError.AddressMismatch;
+                }
+
+                // Clear BSS
+                const bss = @as([*]u8, @ptrFromInt(bss_start))[0..bss_end - bss_start];
+                @memset(bss, 0);
+
+                // Flush store pipe
+                asm volatile ("dmb" ::: .{ .memory = true });
+
+                // Return the entry point
+                return .{ .xip = false, .offset = @intCast(@intFromPtr(cart_descriptor) - cart_ram_start) };
+            },
+            else => {
+                return LoadError.VersionMismatch;
+            },
+        }
+    }
+
+    // Find the vector table by scanning for valid SP and entry point pattern
+    // Some toolchains add padding before the vector table
+    // Returns the vector table ADDRESS (not entry point) so Core 1 can read both SP and entry
+    const vector_table_addr = findVectorTableAddr(cart_xip_start + min_xip_offset, cart_xip_end) orelse {
         log.debug("findVectorTableAddr: vector not found after programming", .{});
         return LoadError.FlashWriteError;
     };
@@ -433,7 +502,7 @@ fn loadUF2FromStorage(cart_info: storage.CartInfo) LoadError!u32 {
         log.debug("Post-program verification OK: vt=0x{x} sp=0x{x} entry=0x{x}", .{ vector_table_addr, sp, entry });
     }
 
-    return vector_table_addr;
+    return .{ .xip = true, .offset = @intCast(vector_table_addr - cart_xip_start) };
 }
 
 /// Erase the entire cart_xip flash region

--- a/src/os/loader/storage.zig
+++ b/src/os/loader/storage.zig
@@ -740,6 +740,39 @@ pub fn deleteCart(name: []const u8) bool {
     return false;
 }
 
+pub const FileIterator = struct {
+    bytes_left: usize,
+    cluster: u16,
+    sector_index: u8,
+
+    pub fn init(size: u32, start_cluster: u16) @This() {
+        return .{ .bytes_left = size, .cluster = start_cluster, .sector_index = 0 };
+    }
+
+    pub fn next(it: *@This()) ?[]align(4) const u8 {
+        if (it.bytes_left == 0) return null;
+
+        if (it.sector_index >= SECTORS_PER_CLUSTER) {
+            it.cluster = fatEntry(it.cluster, &sector_bufs[0], &sector_bufs[1]);
+            it.sector_index = 0;
+        }
+
+        if (it.cluster < 2 or it.cluster >= 0xFFF8) {
+            it.bytes_left = 0;
+            return null;
+        }
+
+        const lba = clusterToLba(it.cluster) + it.sector_index;
+        readSector(lba, sector_bufs[0][0..]);
+
+        const valid_len: usize = @min(it.bytes_left, SECTOR_SIZE);
+        it.sector_index += 1;
+        it.bytes_left -= valid_len;
+
+        return sector_bufs[0][0..valid_len];
+    }
+};
+
 pub fn readCart(cart: CartInfo, dst: []u8) u32 {
     if (cart.size == 0) return 0;
     var bytes_left: u32 = cart.size;

--- a/src/os/loader/uf2.zig
+++ b/src/os/loader/uf2.zig
@@ -79,7 +79,7 @@ pub const Block = extern struct {
     }
 
     /// Get the payload data slice (only the used portion)
-    pub fn getPayload(self: *const Block) []const u8 {
+    pub fn getPayload(self: *const Block) []align(4) const u8 {
         const size = @min(self.header.payload_size, MAX_PAYLOAD_SIZE);
         return self.data[0..size];
     }
@@ -119,8 +119,8 @@ pub const Parser = struct {
 
     /// Parse and validate a single UF2 block
     /// Returns the block if valid, or an error
-    pub fn parseBlock(self: *Parser, data: []const u8) Error!*const Block {
-        const block: *const Block = @ptrCast(@alignCast(data));
+    pub fn parseBlock(self: *Parser, data: *align(4) const [BLOCK_SIZE]u8) Error!*const Block {
+        const block: *const Block = @ptrCast(data);
 
         // Validate magic numbers
         if (!block.isValid()) {
@@ -158,27 +158,9 @@ pub const Parser = struct {
             return Error.InvalidBlockNumber;
         }
 
-        // Track address range
-        const addr = block.header.target_addr;
-        const end_addr = addr + block.header.payload_size;
-        if (addr < self.min_addr) {
-            self.min_addr = addr;
-        }
-        if (end_addr > self.max_addr) {
-            self.max_addr = end_addr;
-        }
-
         self.blocks_parsed += 1;
 
         return block;
-    }
-
-    /// Check if a target address range is valid for cart execution
-    pub fn validateAddressRange(self: *const Parser, cart_xip_start: u32, cart_xip_end: u32) Error!void {
-        // Check if the UF2's address range fits within cart_xip
-        if (self.min_addr < cart_xip_start or self.max_addr > cart_xip_end) {
-            return Error.AddressOutOfRange;
-        }
     }
 
     /// Get the total binary size (max_addr - min_addr)

--- a/src/os/system/console.zig
+++ b/src/os/system/console.zig
@@ -1289,6 +1289,7 @@ fn cmdLoad(iter: *std.mem.TokenIterator(u8, .scalar)) void {
             loader.LoadError.InvalidUF2 => println("Invalid UF2 format\r\n"),
             loader.LoadError.UnsupportedFamily => println("Unsupported chip family (need RP2354B)\r\n"),
             loader.LoadError.AddressMismatch => println("UF2 not linked for cart_xip region (0x101C0000)\r\n"),
+            loader.LoadError.VersionMismatch => println("Cart has unknown version\r\n"),
             loader.LoadError.FlashWriteError => println("Flash write error\r\n"),
             loader.LoadError.ReadError => println("Storage read error\r\n"),
         }
@@ -1342,7 +1343,7 @@ fn cmdCart(iter: *std.mem.TokenIterator(u8, .scalar)) void {
         };
         printf("  State: {s}\r\n", .{state_str});
         if (state == .ready or state == .running) {
-            printf("  Entry point: 0x{x}\r\n", .{loader.getEntryPoint()});
+            printf("  Entry point: {any}\r\n", .{loader.getEntryPoint()});
         }
         printf("  Cart XIP region: 0x{x} - 0x{x} ({d}KB)\r\n", .{
             loader.getCartXipStart(),
@@ -1383,7 +1384,7 @@ fn cmdCart(iter: *std.mem.TokenIterator(u8, .scalar)) void {
         }
         const entry = loader.getEntryPoint();
         if (multicore.executeCart(entry)) {
-            printf("\r\nExecuting cart at 0x{x}...\r\n", .{entry});
+            printf("\r\nExecuting cart at {any}...\r\n", .{entry});
         } else {
             println("\r\nFailed to execute cart\r\n");
         }
@@ -1440,6 +1441,7 @@ fn cmdCart(iter: *std.mem.TokenIterator(u8, .scalar)) void {
                 loader.LoadError.InvalidUF2 => println("Invalid UF2 format\r\n"),
                 loader.LoadError.UnsupportedFamily => println("Unsupported chip family (need RP2354B)\r\n"),
                 loader.LoadError.AddressMismatch => println("UF2 not linked for cart_xip region (0x101C0000)\r\n"),
+                loader.LoadError.VersionMismatch => println("Cart has unknown version\r\n"),
                 loader.LoadError.FlashWriteError => println("Flash write error\r\n"),
                 loader.LoadError.ReadError => println("Storage read error\r\n"),
             }
@@ -1452,7 +1454,7 @@ fn cmdCart(iter: *std.mem.TokenIterator(u8, .scalar)) void {
             // Mark as running from Core 0 side
             // (Core 1 also calls markRunning but this ensures state is set immediately)
             loader.markRunning();
-            printf("Cart running at 0x{x}\r\n\r\n", .{entry_point});
+            printf("Cart running at {any}\r\n\r\n", .{entry_point});
         } else {
             println("Failed to start cart execution\r\n");
         }

--- a/src/os/system/multicore.zig
+++ b/src/os/system/multicore.zig
@@ -179,29 +179,13 @@ fn getCartXipStart() u32 {
 /// Execute a cart that has been loaded into cart_xip
 /// entry_point: Full 32-bit entry point address
 /// Returns true if message was sent successfully
-pub fn executeCart(entry_point: u32) bool {
+pub fn executeCart(msg: mailbox.MessageType.CartExecute) bool {
     if (!core1_running) {
         return false;
     }
 
-    const cart_xip_start = getCartXipStart();
-
-    // Calculate offset from cart_xip_start
-    // Entry point must be within cart_xip region
-    if (entry_point < cart_xip_start) {
-        return false;
-    }
-
-    const offset = entry_point - cart_xip_start;
-
-    // Offset must fit in 24 bits (256KB = 0x40000, fits in 24 bits)
-    if (offset > 0xFFFFFF) {
-        return false;
-    }
-
     // Send CART_EXECUTE message to Core 1
-    const msg = mailbox.MessageType.cartExecute(@intCast(offset));
-    mailbox.send(msg);
+    mailbox.send(@bitCast(msg));
 
     return true;
 }


### PR DESCRIPTION
Ram carts place their physical memory addresses in SRAM, which will be loaded by the OS. They also specify a CartDescriptor, which contains startup information for the OS. CartDescriptors give us a way to handle carts compiled against different OS versions the day of, by providing backwards compatibility or at least rejecting unrecognized versions.

Legacy XIP carts with a flash footprint and vector table are still supported.

The loader now also supports hybrid-mode carts, which map physical addresses in both RAM and flash memory. All flash memory must precede RAM memory in the file layout, but they can coexist. This is probably not a great solution, and we should look to support streaming files off of the FAT filesystem into cart RAM instead, but for now it's better than nothing.