### PR TITLE
Fix audio frequency for rev1

### DIFF
--- a/src/os/drivers/audio.zig
+++ b/src/os/drivers/audio.zig
@@ -253,6 +253,18 @@ var mix_state: terry.core0.TrackedStateMachine(MixState) = undefined;
 
 var period_per_sample: f32 = 0;
 var phase: f32 = 0;
+fn mix_audio_square(comptime impl: type, noalias buf: []impl.Sample) void {
+    for (buf, 0..) |*sample, i| {
+        const f: f32 = @floatFromInt(i);
+        const samp_phase = phase + period_per_sample * f;
+        const fract_phase = samp_phase - @trunc(samp_phase);
+        const vol_adj = if (fract_phase < 0.5) vol_amplitude else -vol_amplitude;
+        sample.* = impl.encode_sample(vol_adj);
+    }
+    phase += @as(f32, @floatFromInt(buf.len)) * period_per_sample;
+    phase = phase - @trunc(phase);
+}
+
 fn mix_audio_sawtooth(comptime impl: type, noalias buf: []impl.Sample) void {
     for (buf, 0..) |*sample, i| {
         const f: f32 = @floatFromInt(i);
@@ -301,7 +313,8 @@ fn mix_buffer(buffer: *align(64) [dma_buf_size]u32) bool {
 
 noinline fn mix_buffer_samples(comptime impl: type, buffer: []impl.Sample, samples_to_mix: u32) bool {
     switch (sound_type.state) {
-        .off, .square => {}, // mixer shouldn't be in use
+        .off => {}, // mixer shouldn't be in use
+        .square => mix_audio_square(impl, buffer[0..samples_to_mix]),
         .sawtooth => mix_audio_sawtooth(impl, buffer[0..samples_to_mix]),
         .triangle => mix_audio_triangle(impl, buffer[0..samples_to_mix]),
         .sample => {
@@ -447,6 +460,7 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32, flags: u32) void {
     } else {
         period_per_sample = freq_hz / max_sample_rate;
         switch (sample_sel) {
+            0 => sound_type.set_state(.square, @src()),
             1 => sound_type.set_state(.triangle, @src()),
             2 => sound_type.set_state(.sawtooth, @src()),
             else => {

--- a/src/os/drivers/audio.zig
+++ b/src/os/drivers/audio.zig
@@ -170,8 +170,11 @@ const rev0 = struct {
 };
 
 const rev1 = struct {
-    const Sample = i16;
-    const I2S = @import("../drivers/i2s.zig").I2S(Sample, .{ .sample_rate = max_sample_rate });
+    const Sample = packed struct(u32) {
+        right: i16,
+        left: i16,
+    };
+    const I2S = @import("../drivers/i2s.zig").I2S(i16, .{ .sample_rate = max_sample_rate, .stereo_mode = .packed_samples });
     var i2s: I2S = undefined;
 
     fn init() void {
@@ -207,14 +210,15 @@ const rev1 = struct {
                 const base = @backingInt(TransferRequest.pio0_tx0);
                 break :blk @fromBackingInt(base + (stride * @backingInt(i2s.pio)) + @backingInt(i2s.sm)); // + 0 for tx
             },
-            .data_size = .size_16,
-            .ring_size = @fromBackingInt(@intCast(log2_dma_buf_size + 1)),
+            .data_size = .size_32,
+            .ring_size = @fromBackingInt(@intCast(log2_dma_buf_size + 2)),
             .write_addr = @intFromPtr(i2s.pio.sm_get_tx_fifo(i2s.sm)),
         };
     }
 
     fn encode_sample(val: f32) Sample {
-        return @intFromFloat(std.math.clamp(val, -1.0, 1.0) * @as(f32, @floatFromInt(std.math.maxInt(i16))));
+        const mono_val: i16 = @intFromFloat(std.math.clamp(val, -1.0, 1.0) * @as(f32, @floatFromInt(std.math.maxInt(i16))));
+        return .{ .left = mono_val, .right = mono_val };
     }
 };
 
@@ -305,10 +309,14 @@ fn mix_buffer(buffer: *align(64) [dma_buf_size]u32) bool {
         }
     } else dma_buf_size;
 
-    return if (@backingInt(rev.revision) < 1)
-        mix_buffer_samples(rev0, buffer, samples_to_mix)
+    const more_buffers = if (@backingInt(rev.revision) < 1)
+        mix_buffer_samples(rev0, @as([*]rev0.Sample, @ptrCast(buffer))[0..dma_buf_size], samples_to_mix)
     else
-        mix_buffer_samples(rev1, @as([*]i16, @ptrCast(buffer))[0..dma_buf_size], samples_to_mix);
+        mix_buffer_samples(rev1, @as([*]rev1.Sample, @ptrCast(buffer))[0..dma_buf_size], samples_to_mix);
+
+    asm volatile ("dmb" ::: .{ .memory = true });
+
+    return more_buffers;
 }
 
 noinline fn mix_buffer_samples(comptime impl: type, buffer: []impl.Sample, samples_to_mix: u32) bool {
@@ -379,7 +387,6 @@ pub fn poll() void {
 
             const start = timer.micros();
             const more_buffers = mix_buffer(&audio_dma_buf[mix_idx]);
-            std.mem.doNotOptimizeAway(&audio_dma_buf[mix_idx]);
             if (!more_buffers) {
                 mix_state.set_state(.shutting_down, @src());
                 // Turn off the continuation after the mixed buffer

--- a/src/os/drivers/i2s.zig
+++ b/src/os/drivers/i2s.zig
@@ -10,8 +10,22 @@ const gpio = rp2xxx.gpio;
 
 const log = std.log.scoped(.i2s);
 
+pub const StereoMode = enum {
+    // Samples in the fifo alternate between left and right,
+    // with left coming before right
+    alternate_samples,
+    // Samples in the fifo are packed into single words,
+    // with the left channel in the high bits and the
+    // right channel in the low bits.
+    packed_samples,
+};
+
 pub fn I2S(comptime Sample: type, comptime args: struct {
     sample_rate: u32,
+    // When set, an individual item in the fifo is two samples
+    // packed together, with the left sample in the high bits
+    // and the right sample in the low bits.
+    stereo_mode: StereoMode = .alternate_samples,
 }) type {
     switch (args.sample_rate) {
         8_000,
@@ -108,7 +122,10 @@ pub fn I2S(comptime Sample: type, comptime args: struct {
                 }),
                 .shift = .{
                     .autopull = true,
-                    .pull_threshold = @as(u5, @truncate(sample_width)),
+                    .pull_threshold = switch (args.stereo_mode) {
+                        .packed_samples => @as(u5, @truncate(sample_width * 2)),
+                        .alternate_samples => @as(u5, @truncate(sample_width)),
+                    },
                     .join_tx = true,
                     .out_shiftdir = .left,
                 },
@@ -135,16 +152,24 @@ pub fn I2S(comptime Sample: type, comptime args: struct {
         const UnsignedSample = @Int(.unsigned, @bitSizeOf(Sample));
         fn sample_to_fifo_entry(sample: Sample) u32 {
             const sample_shift = comptime 32 - sample_width;
-            return @as(
+            return @shlExact(@as(
                 u32,
                 @intCast(@as(UnsignedSample, @bitCast(sample))),
-            ) << sample_shift;
+            ), sample_shift);
         }
 
         pub fn write_mono(self: Self, sample: Sample) void {
             const value = sample_to_fifo_entry(sample);
-            self.pio.sm_write(self.sm, value);
-            self.pio.sm_write(self.sm, value);
+            switch (args.stereo_mode) {
+                .packed_samples =>
+                    self.pio.sm_write(
+                        value | @shrExact(value, sample_width),
+                    ),
+                .alternate_samples => {
+                    self.pio.sm_write(self.sm, value);
+                    self.pio.sm_write(self.sm, value);
+                },
+            }
         }
 
         pub const StereoSample = struct {
@@ -153,13 +178,31 @@ pub fn I2S(comptime Sample: type, comptime args: struct {
         };
 
         pub fn write_stereo(self: Self, sample: StereoSample) void {
-            self.pio.sm_write(self.sm, sample_to_fifo_entry(sample.left));
-            self.pio.sm_write(self.sm, sample_to_fifo_entry(sample.right));
+            switch (args.stereo_mode) {
+                .packed_samples =>
+                    self.pio.sm_write(
+                        sample_to_fifo_entry(sample.left) |
+                        @shrExact(sample_to_fifo_entry(sample.right), sample_width)
+                    ),
+                .alternate_samples => {
+                    self.pio.sm_write(self.sm, sample_to_fifo_entry(sample.left));
+                    self.pio.sm_write(self.sm, sample_to_fifo_entry(sample.right));
+                },
+            }
         }
 
         pub fn write_stereo_blocking(self: Self, sample: StereoSample) void {
-            self.pio.sm_blocking_write(self.sm, sample_to_fifo_entry(sample.left));
-            self.pio.sm_blocking_write(self.sm, sample_to_fifo_entry(sample.right));
+            switch (args.stereo_mode) {
+                .packed_samples =>
+                    self.pio.sm_write(
+                        sample_to_fifo_entry(sample.left) |
+                        @shrExact(sample_to_fifo_entry(sample.right), sample_width)
+                    ),
+                .alternate_samples => {
+                    self.pio.sm_blocking_write(self.sm, sample_to_fifo_entry(sample.left));
+                    self.pio.sm_blocking_write(self.sm, sample_to_fifo_entry(sample.right));
+                },
+            }
         }
     };
 }

--- a/src/os/drivers/i2s.zig
+++ b/src/os/drivers/i2s.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const EnumField = std.builtin.Type.EnumField;
-const StructField = std.builtin.Type.StructField;
 
 const microzig = @import("microzig");
 const assert = microzig.assert;


### PR DESCRIPTION
The I2S PIO expects pairs of stereo samples. This PR updates the mixer to duplicate mono data into stereo, and also adds square wave generation via the mixer for rev1.